### PR TITLE
fix: install kane-cli via npm tarball instead of bare runner binary

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -26,36 +26,52 @@ jobs:
             echo "version=${{ github.event.client_payload.version }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Download checksums from release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Wait for npm package availability
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          # v16's public release workflow tags releases as "0.2.0" (no v prefix);
-          # try the bare tag first, fall back to "v0.2.0" for older releases.
-          if ! gh release download "${VERSION}" --repo LambdaTest/kane-cli --pattern SHA256SUMS --dir . 2>/dev/null; then
-            gh release download "v${VERSION}" --repo LambdaTest/kane-cli --pattern SHA256SUMS --dir .
-          fi
+          PKG="@testmuai/kane-cli"
+          echo "Waiting for ${PKG}@${VERSION} on npmjs.com..."
+          for i in $(seq 1 24); do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              "https://registry.npmjs.org/${PKG}/${VERSION}")
+            if [ "$STATUS" = "200" ]; then
+              echo "${PKG}@${VERSION} is available."
+              exit 0
+            fi
+            echo "Poll ${i}/24 — HTTP ${STATUS}, sleeping 5s..."
+            sleep 5
+          done
+          echo "ERROR: ${PKG}@${VERSION} not visible on npmjs.com after 2m"
+          exit 1
+
+      - name: Compute tarball sha256
+        id: tarball
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          TARBALL_URL="https://registry.npmjs.org/@testmuai/kane-cli/-/kane-cli-${VERSION}.tgz"
+
+          curl -fsSL "$TARBALL_URL" -o kane-cli.tgz
+          SHA256=$(sha256sum kane-cli.tgz | awk '{print $1}')
+
+          echo "tarball-url=${TARBALL_URL}" >> "$GITHUB_OUTPUT"
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+          echo "Tarball: ${TARBALL_URL}"
+          echo "sha256:  ${SHA256}"
 
       - name: Update formula
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          TARBALL_URL="${{ steps.tarball.outputs.tarball-url }}"
+          SHA256="${{ steps.tarball.outputs.sha256 }}"
           FORMULA="Formula/kane-cli.rb"
 
-          # Extract checksums
-          DARWIN_SHA=$(awk '/kane-cli-darwin-arm64$/{print $1}' SHA256SUMS)
-          LINUX_SHA=$(awk '/kane-cli-linux-x64$/{print $1}' SHA256SUMS)
+          # url, sha256, version are all single occurrences in the formula now
+          # (no per-platform blocks).
+          sed -i "s|^  url \".*\"|  url \"${TARBALL_URL}\"|" "$FORMULA"
+          sed -i "s|^  sha256 \".*\"|  sha256 \"${SHA256}\"|" "$FORMULA"
+          sed -i "s|^  version \".*\"|  version \"${VERSION}\"|" "$FORMULA"
 
-          # Update version
-          sed -i "s/version \".*\"/version \"${VERSION}\"/" "$FORMULA"
-
-          # Update sha256 values — match the line after the url line for each platform
-          # darwin-arm64
-          sed -i "/kane-cli-darwin-arm64/{ n; s/sha256 \".*\"/sha256 \"${DARWIN_SHA}\"/; }" "$FORMULA"
-          # linux-x64
-          sed -i "/kane-cli-linux-x64/{ n; s/sha256 \".*\"/sha256 \"${LINUX_SHA}\"/; }" "$FORMULA"
-
-          echo "Updated formula to v${VERSION}:"
+          echo "Updated formula to ${VERSION}:"
           cat "$FORMULA"
 
       - name: Commit and push
@@ -64,5 +80,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/kane-cli.rb
-          git commit -m "Update kane-cli to v${VERSION}"
+          git diff --cached --quiet && { echo "No changes to commit."; exit 0; }
+          git commit -m "Update kane-cli to ${VERSION}"
           git push

--- a/Formula/kane-cli.rb
+++ b/Formula/kane-cli.rb
@@ -4,29 +4,21 @@
 class KaneCli < Formula
   desc "KaneAI browser automation CLI - AI-powered testing"
   homepage "https://www.lambdatest.com/kane-ai"
+  url "https://registry.npmjs.org/@testmuai/kane-cli/-/kane-cli-0.2.0.tgz"
+  sha256 "80d2d9da29574d65397172c4ad28e7b54b7f47f71147cfea3e181447ec75a5d5"
   license "Apache-2.0"
   version "0.2.0"
 
-  on_macos do
-    on_arm do
-      url "https://github.com/LambdaTest/kane-cli/releases/download/#{version}/kane-cli-darwin-arm64"
-      sha256 "3e07b923e6720d107d03914e3367b07289eee794d555a1e59be07941c3f86386"
-    end
-  end
-
-  on_linux do
-    on_intel do
-      url "https://github.com/LambdaTest/kane-cli/releases/download/#{version}/kane-cli-linux-x64"
-      sha256 "ea5bc82d4d4858454595c1d5a934f7921e11192a45394f0213e42f0394e0a069"
-    end
-  end
+  depends_on "node"
 
   def install
-    if OS.mac?
-      bin.install "kane-cli-darwin-arm64" => "kane-cli"
-    elsif OS.linux?
-      bin.install "kane-cli-linux-x64" => "kane-cli"
-    end
+    system "npm", "install", *std_npm_args
+    bin.install_symlink libexec.glob("bin/*")
+
+    # The npm meta package declares optionalDependencies on platform-specific
+    # native binary packages (@testmuai/kane-cli-{darwin-arm64,linux-x64,win-x64}).
+    # npm installs only the matching one for the current platform — the others
+    # are silently skipped and never present, so no cleanup is required here.
   end
 
   def caveats


### PR DESCRIPTION
## Summary

Brew users currently get a different (and broken-looking) command than npm users. This PR switches the formula to install via the npm tarball so both paths produce the same install.

## Background

The release on \`LambdaTest/kane-cli\` ships these binaries:
\`\`\`
kane-cli-darwin-arm64    ← actually v16-runner, renamed
kane-cli-linux-x64       ← same
kane-cli-win-x64.exe     ← same
\`\`\`

Those are the bare Python/Nuitka agent (\`v16-runner\`). The actual user-facing CLI is the Node.js TUI shipped via \`@testmuai/kane-cli\` on npm — that wraps \`v16-runner\` as a subprocess.

The old formula installed the bare runner as \`kane-cli\`, so:
- \`brew install LambdaTest/kane/kane-cli && kane-cli\` → no TUI, expects NDJSON config on stdin, errors out
- \`npm install -g @testmuai/kane-cli && kane-cli\` → interactive Ink TUI

## Approach

Adopt the [agent-browser pattern](https://formulae.brew.sh/formula/agent-browser) — Homebrew's existing formula for a similar Node-based CLI tool.

\`\`\`ruby
url "https://registry.npmjs.org/@testmuai/kane-cli/-/kane-cli-0.2.0.tgz"
sha256 "..."
depends_on "node"

def install
  system "npm", "install", *std_npm_args
  bin.install_symlink libexec.glob("bin/*")
end
\`\`\`

\`npm install\` resolves \`@testmuai/kane-cli\`'s \`optionalDependencies\` and pulls only the matching platform binary package — same as the npm install path.

## Auto-update workflow

Rewritten so it works against the new formula structure:
- Polls npmjs.com for the new version (up to 2min — handles npm CDN propagation)
- Computes tarball sha256 directly from the registry
- Updates \`url\` / \`sha256\` / \`version\` (single occurrences each — no per-platform blocks anymore)
- Idempotent — skips commit if nothing changed

## Test plan

- [ ] \`brew install LambdaTest/kane/kane-cli\` after this merges and the repo is public — should run \`npm install\`, install Node-based TUI
- [ ] \`kane-cli --version\` prints \`0.2.0\`
- [ ] \`kane-cli\` (no args) launches the same Ink TUI as the npm install
- [ ] On next \`build-cli.yml\` public release, the formula auto-update workflow polls for the new version and updates the formula in one step

🤖 Generated with [Claude Code](https://claude.com/claude-code)