### PR TITLE
fix: install.sh delegates to npm so curl install matches npm/brew

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,16 @@ brew install LambdaTest/kane/kane-cli
 ### Shell script
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | sh
 ```
 
-Options:
+Installs a specific version:
 
 ```bash
-# Install a specific version
-curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | bash -s -- --version 0.2.0
-
-# Install to a custom directory
-curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | bash -s -- --dir /usr/local/bin
+curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | sh -s -- --version 0.2.0
 ```
+
+> Requires Node.js 18+ and npm. The script delegates to `npm install -g @testmuai/kane-cli` so you get the same install as the npm method above. For an install that doesn't need Node, use Homebrew.
 
 ## Supported platforms
 
@@ -116,7 +114,7 @@ npm update -g @testmuai/kane-cli
 brew upgrade kane-cli
 
 # curl installer
-curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | sh
 ```
 
 ## Contributing

--- a/install.sh
+++ b/install.sh
@@ -1,151 +1,97 @@
-#!/usr/bin/env bash
-# kane-cli installer — detects OS/arch, downloads the right binary from GitHub Releases.
+#!/usr/bin/env sh
+# kane-cli installer — installs the @testmuai/kane-cli npm package globally.
+#
+# This script delegates to npm so all install methods (npm / brew / curl)
+# produce the same install: the Node.js TUI plus the matching native runner
+# binary resolved via optionalDependencies.
 #
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | bash
-#   curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | bash -s -- --version 0.2.0
-#   curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | bash -s -- --dir /usr/local/bin
+#   curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh | sh -s -- --version 0.2.0
 #
-set -euo pipefail
+# Requires: Node.js 18+ and npm on PATH.
+# For an install path that doesn't need Node, use Homebrew:
+#   brew install LambdaTest/kane/kane-cli
 
-REPO="LambdaTest/kane-cli"
-INSTALL_DIR="${HOME}/.local/bin"
+set -eu
+
+PACKAGE="@testmuai/kane-cli"
 VERSION=""
-BINARY_NAME="kane-cli"
 
 # ── Parse args ──────────────────────────────────────────────────────────
-while [[ $# -gt 0 ]]; do
+while [ $# -gt 0 ]; do
   case "$1" in
-    --version) VERSION="$2"; shift 2 ;;
-    --dir)     INSTALL_DIR="$2"; shift 2 ;;
-    --help)
-      echo "Usage: install.sh [--version X.Y.Z] [--dir /path/to/bin]"
-      echo ""
-      echo "Options:"
-      echo "  --version   Specific version to install (default: latest)"
-      echo "  --dir       Install directory (default: ~/.local/bin)"
+    --version)
+      VERSION="$2"
+      shift 2
+      ;;
+    --help|-h)
+      cat <<EOF
+Usage: install.sh [--version X.Y.Z]
+
+Installs ${PACKAGE} globally via npm.
+
+Options:
+  --version   Specific version to install (default: latest)
+
+Requires Node.js 18+ and npm on PATH. For a non-npm install:
+  brew install LambdaTest/kane/kane-cli
+EOF
       exit 0
       ;;
-    *) echo "Unknown option: $1"; exit 1 ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
   esac
 done
 
-# ── Detect platform ────────────────────────────────────────────────────
-detect_platform() {
-  local os arch
+# ── Check prerequisites ────────────────────────────────────────────────
+if ! command -v npm >/dev/null 2>&1; then
+  cat >&2 <<EOF
+Error: npm is required but not found on PATH.
 
-  os="$(uname -s | tr '[:upper:]' '[:lower:]')"
-  arch="$(uname -m)"
+Install Node.js 18+ from https://nodejs.org and try again, or use Homebrew:
+  brew install LambdaTest/kane/kane-cli
+EOF
+  exit 1
+fi
 
-  case "$os" in
-    darwin) os="darwin" ;;
-    linux)  os="linux" ;;
-    mingw*|msys*|cygwin*)
-      echo "Error: This installer does not support Windows. Use npm instead:"
-      echo "  npm install -g @testmuai/kane-cli"
-      exit 1
-      ;;
-    *) echo "Error: Unsupported OS: $os"; exit 1 ;;
-  esac
-
-  case "$arch" in
-    arm64|aarch64) arch="arm64" ;;
-    x86_64|amd64)  arch="x64" ;;
-    *) echo "Error: Unsupported architecture: $arch"; exit 1 ;;
-  esac
-
-  # Only supported combos
-  case "${os}-${arch}" in
-    darwin-arm64|linux-x64) ;;
-    *) echo "Error: Unsupported platform: ${os}-${arch}"; exit 1 ;;
-  esac
-
-  echo "${os}-${arch}"
-}
-
-# ── Resolve latest version ─────────────────────────────────────────────
-resolve_version() {
-  if [[ -n "$VERSION" ]]; then
-    echo "$VERSION"
-    return
-  fi
-
-  local latest
-  latest=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
-    | grep '"tag_name"' \
-    | sed -E 's/.*"v([^"]+)".*/\1/')
-
-  if [[ -z "$latest" ]]; then
-    echo "Error: Could not determine latest version" >&2
+# ── Reject Windows ─────────────────────────────────────────────────────
+case "$(uname -s 2>/dev/null || echo unknown)" in
+  MINGW*|MSYS*|CYGWIN*|Windows_NT)
+    cat >&2 <<EOF
+Error: This shell installer is POSIX-only. On Windows, install via npm directly:
+  npm install -g ${PACKAGE}
+EOF
     exit 1
-  fi
+    ;;
+esac
 
-  echo "$latest"
-}
+# ── Install ────────────────────────────────────────────────────────────
+if [ -n "$VERSION" ]; then
+  SPEC="${PACKAGE}@${VERSION}"
+else
+  SPEC="${PACKAGE}"
+fi
 
-# ── Download + verify ──────────────────────────────────────────────────
-main() {
-  local platform version asset_name download_url tmp_dir
+echo "Installing ${SPEC} via npm..."
+echo
 
-  platform="$(detect_platform)"
-  version="$(resolve_version)"
-
-  echo "Installing kane-cli v${version} for ${platform}..."
-
-  # Determine asset name
-  if [[ "$platform" == "win-x64" ]]; then
-    asset_name="kane-cli-win-x64.exe"
+# Try without sudo first (works for nvm/fnm/volta and prefix-configured npm).
+# Fall back to sudo only if a permission error suggests it.
+if npm install -g "$SPEC"; then
+  : # success
+else
+  EXIT=$?
+  if [ $EXIT -eq 13 ] || [ $EXIT -eq 243 ]; then
+    echo
+    echo "npm install failed with a permission error. Retrying with sudo..."
+    sudo npm install -g "$SPEC"
   else
-    asset_name="kane-cli-${platform}"
+    exit $EXIT
   fi
+fi
 
-  download_url="https://github.com/${REPO}/releases/download/v${version}/${asset_name}"
-
-  # Download to temp
-  tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$tmp_dir"' EXIT
-
-  echo "Downloading ${download_url}..."
-  if ! curl -fsSL -o "${tmp_dir}/${asset_name}" "$download_url"; then
-    echo "Error: Download failed. Check that version v${version} exists at:"
-    echo "  https://github.com/${REPO}/releases"
-    exit 1
-  fi
-
-  # Verify checksum if SHA256SUMS available
-  local checksums_url="https://github.com/${REPO}/releases/download/v${version}/SHA256SUMS"
-  if curl -fsSL -o "${tmp_dir}/SHA256SUMS" "$checksums_url" 2>/dev/null; then
-    echo "Verifying checksum..."
-    if ! (cd "$tmp_dir" && grep "  ${asset_name}$" SHA256SUMS | sha256sum -c --quiet 2>/dev/null) && \
-       ! (cd "$tmp_dir" && grep "  ${asset_name}$" SHA256SUMS | shasum -a 256 -c --quiet 2>/dev/null); then
-      echo "Error: Checksum verification failed. Aborting."
-      exit 1
-    fi
-    echo "Checksum verified."
-  else
-    echo "Warning: SHA256SUMS not available, skipping checksum verification."
-  fi
-
-  # Install
-  mkdir -p "$INSTALL_DIR"
-  cp "${tmp_dir}/${asset_name}" "${INSTALL_DIR}/${BINARY_NAME}"
-  chmod +x "${INSTALL_DIR}/${BINARY_NAME}"
-
-  echo ""
-  echo "Installed kane-cli v${version} to ${INSTALL_DIR}/${BINARY_NAME}"
-
-  # Check if install dir is in PATH
-  if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
-    echo ""
-    echo "Add to your PATH:"
-    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
-    echo ""
-    echo "Or move the binary to a directory already in your PATH:"
-    echo "  sudo mv ${INSTALL_DIR}/${BINARY_NAME} /usr/local/bin/"
-  fi
-
-  echo ""
-  echo "Run 'kane-cli --version' to verify."
-}
-
-main
+echo
+echo "Installed. Run 'kane-cli --version' to verify."


### PR DESCRIPTION
## Summary

Same root issue as #1, but for the curl installer. Both install paths now converge on the npm package.

## Background

Old install.sh downloaded \`kane-cli-darwin-arm64\` (etc.) from GitHub Releases and renamed it to \`kane-cli\`. Those release assets are the bare \`v16-runner\` binary — Python/Nuitka agent — not the Node.js TUI users get from \`npm install -g @testmuai/kane-cli\`.

Result:
- \`npm install -g @testmuai/kane-cli\` → interactive Ink TUI ✅
- \`brew install LambdaTest/kane/kane-cli\` (after #1) → same TUI ✅
- \`curl ... | sh\` → bare runner, no TUI, broken UX ❌

## Approach

Rewrite install.sh as a thin wrapper around npm:

\`\`\`sh
# Check npm is on PATH
# Reject Windows (point to npm directly)
# Run: npm install -g @testmuai/kane-cli[@VERSION]
# Retry once with sudo only if first attempt fails with EACCES (preserves nvm/fnm/volta UX)
\`\`\`

Trade-off: requires Node 18+. For users who don't want Node, Homebrew is the no-Node path (formula installs Node via depends_on but bin lives under brew prefix).

## README updated

- curl example now pipes to \`sh\` (POSIX, not bash-only)
- Dropped \`--dir\` flag (npm picks the install dir)
- Added a note: needs Node; for no-Node install, use Homebrew

## Test plan

- [ ] On a clean macOS / Linux machine with npm: \`curl -fsSL .../install.sh | sh\` installs and \`kane-cli --version\` works
- [ ] Without npm on PATH: clear error with pointer to nodejs.org / brew
- [ ] On Windows (msys/cygwin): clear error with pointer to \`npm install -g\`
- [ ] \`--version 0.2.0\` flag pins to that version
- [ ] After #388 ships in 0.2.1: \`curl install\` produces the same working TUI as npm/brew

🤖 Generated with [Claude Code](https://claude.com/claude-code)