### PR TITLE
docs: remove stale Signature Verification section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,25 +50,6 @@ curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh
 | Linux    | x64                   | Signed (OpenSSL)      |
 | Windows  | x64                   | Signed (Authenticode) |
 
-## Signature verification
-
-### macOS
-
-Automatic — macOS Gatekeeper verifies the Apple notarization on first launch.
-
-### Linux
-
-```bash
-curl -LO https://github.com/LambdaTest/kane-cli/releases/latest/download/kane-cli-linux-x64.sig
-curl -LO https://github.com/LambdaTest/kane-cli/releases/latest/download/public_key.pem
-
-openssl dgst -sha256 -verify public_key.pem -signature kane-cli-linux-x64.sig kane-cli-linux-x64
-```
-
-### Windows
-
-Automatic — Windows SmartScreen verifies the Authenticode signature.
-
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary

Removes the README "Signature verification" section. It instructed users to download \`kane-cli-linux-x64.sig\` and \`public_key.pem\` from GitHub Releases to manually verify the binary's OpenSSL signature.

## Why

Now that npm / brew / curl all install via the \`@testmuai/kane-cli\` npm package (#1, #2), regular users never touch the bare release binaries — the section pointed at artifacts they don't have.

The macOS/Windows subsections were also trivially true (Gatekeeper / SmartScreen verify automatically on first launch) and added no actionable info.

## Note

Release artifacts and \`public_key.pem\` still exist on GitHub Releases for advanced users who want to verify the bare runner directly. We can document that path separately later if there's demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)