### PR TITLE
docs: document Chrome as a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,16 @@ This is what `kane-cli` is for: any time you (or your coding agent) need a real 
 
 ### npx (recommended for one-off use, CI, or trying it out)
 
-Requires Node 18+. No global install — pulls the package on demand. Pin a version with `@<version>` for reproducibility:
+Requires Node 18+. No global install — pulls the package on demand. Pin a version with `@<version>` for reproducibility. **Cold start downloads Chrome (~150 MB, one-time); subsequent invocations reuse the cache.**
 
 ```bash
+# Verify install (zero-config)
+npx @testmuai/kane-cli@latest --version
+
+# Authenticate first (interactive in a terminal; flag-based in CI)
+npx @testmuai/kane-cli@latest login
+
+# Run an objective
 npx @testmuai/kane-cli@latest run "Go to example.com and assert title contains 'Example'"
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ This is what `kane-cli` is for: any time you (or your coding agent) need a real 
 
 ## Install
 
-### npm (recommended, requires Node 18+)
+### npx (recommended for one-off use, CI, or trying it out)
+
+Requires Node 18+. No global install — pulls the package on demand. Pin a version with `@<version>` for reproducibility:
+
+```bash
+npx @testmuai/kane-cli@latest run "Go to example.com and assert title contains 'Example'"
+```
+
+### npm (install once, run often)
 
 ```bash
 npm install -g @testmuai/kane-cli
@@ -67,6 +75,15 @@ curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh
 ```
 
 Pin a version: append `-s -- --version 0.2.6`.
+
+### About Chrome
+
+On first install, kane-cli downloads a known-good Chrome-for-Testing build (~150 MB) to `~/.cache/kane-cli/chrome`. Subsequent installs and `npx` invocations reuse the cached build.
+
+Skip the auto-download:
+
+- `KANE_CLI_SKIP_BROWSER_DOWNLOAD=1` — install kane-cli without Chrome (run `kane-cli doctor --install-browser` later).
+- `KANE_CLI_CHROME_PATH=/path/to/chrome` — point at an existing Chrome binary instead.
 
 ## First run (under 60 seconds)
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ kane-cli launches your locally installed Google Chrome (stable channel) via the 
 
 - **Homebrew** auto-installs Chrome via the `google-chrome` cask — nothing to do.
 - **`npm install -g` / `npx`**: install Chrome separately if not already present. On first `kane-cli run`, kane-cli verifies Chrome is reachable and produces a clean per-platform error with install instructions if not — re-run after installing Chrome.
-- **Custom path / non-standard install** — set `KANE_CLI_CHROME_PATH=/path/to/chrome`.
 - **Skip the runtime check** (CI / air-gapped) — set `KANE_CLI_SKIP_BROWSER_DOWNLOAD=1`. kane-cli will fall back to whatever `chrome` resolves on PATH.
 
 > Full install reference (platforms, updates, uninstall): [docs/user-guide/installation.md](docs/user-guide/installation.md).

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This is what `kane-cli` is for: any time you (or your coding agent) need a real 
 
 ### npx (recommended for one-off use, CI, or trying it out)
 
-Requires Node 18+. No global install — pulls the package on demand. Pin a version with `@<version>` for reproducibility. **Cold start downloads Chrome (~150 MB, one-time); subsequent invocations reuse the cache.**
+Requires Node 18+ and Google Chrome. No global install — pulls the package on demand. Pin a version with `@<version>` for reproducibility.
 
 ```bash
 # Verify install (zero-config)
@@ -83,14 +83,15 @@ curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh
 
 Pin a version: append `-s -- --version 0.2.6`.
 
-### About Chrome
+### Chrome (required)
 
-On first install, kane-cli downloads a known-good Chrome-for-Testing build (~150 MB) to `~/.cache/kane-cli/chrome`. Subsequent installs and `npx` invocations reuse the cached build.
+kane-cli launches your locally installed Google Chrome (stable channel) via the DevTools Protocol. Chrome must be present at one of the standard system paths (`/Applications/Google Chrome.app/...` on macOS, `/usr/bin/google-chrome` on Linux, `C:\Program Files\Google\Chrome\Application\chrome.exe` on Windows).
 
-Skip the auto-download:
-
-- `KANE_CLI_SKIP_BROWSER_DOWNLOAD=1` — install kane-cli without Chrome (run `kane-cli doctor --install-browser` later).
-- `KANE_CLI_CHROME_PATH=/path/to/chrome` — point at an existing Chrome binary instead.
+- **Homebrew install** auto-installs Chrome via the `google-chrome` cask — nothing to do.
+- **macOS via npm/npx** with no Chrome installed: the postinstall attempts `brew install --cask google-chrome` if `brew` is available; otherwise prints install instructions.
+- **Linux/Windows via npm/npx** with no Chrome installed: the postinstall prints platform-specific install instructions and exits without failing.
+- **Custom path / non-standard install** — set `KANE_CLI_CHROME_PATH=/path/to/chrome`.
+- **Skip the postinstall check** (CI / air-gapped) — set `KANE_CLI_SKIP_BROWSER_DOWNLOAD=1`.
 
 ## First run (under 60 seconds)
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,10 @@ Pin a version: append `-s -- --version 0.2.6`.
 
 kane-cli launches your locally installed Google Chrome (stable channel) via the DevTools Protocol. Chrome must be present at one of the standard system paths (`/Applications/Google Chrome.app/...` on macOS, `/usr/bin/google-chrome` on Linux, `C:\Program Files\Google\Chrome\Application\chrome.exe` on Windows).
 
-- **Homebrew install** auto-installs Chrome via the `google-chrome` cask — nothing to do.
-- **macOS via npm/npx** with no Chrome installed: the postinstall attempts `brew install --cask google-chrome` if `brew` is available; otherwise prints install instructions.
-- **Linux/Windows via npm/npx** with no Chrome installed: the postinstall prints platform-specific install instructions and exits without failing.
+- **Homebrew** auto-installs Chrome via the `google-chrome` cask — nothing to do.
+- **`npm install -g` / `npx`**: install Chrome separately if not already present. On first `kane-cli run`, kane-cli verifies Chrome is reachable and produces a clean per-platform error with install instructions if not — re-run after installing Chrome.
 - **Custom path / non-standard install** — set `KANE_CLI_CHROME_PATH=/path/to/chrome`.
-- **Skip the postinstall check** (CI / air-gapped) — set `KANE_CLI_SKIP_BROWSER_DOWNLOAD=1`.
+- **Skip the runtime check** (CI / air-gapped) — set `KANE_CLI_SKIP_BROWSER_DOWNLOAD=1`. kane-cli will fall back to whatever `chrome` resolves on PATH.
 
 ## First run (under 60 seconds)
 


### PR DESCRIPTION
## Summary

Adds a "Chrome (required)" section to the README documenting that kane-cli needs Google Chrome at standard system paths, with copy-paste install paths per OS and the `KANE_CLI_CHROME_PATH` / `KANE_CLI_SKIP_BROWSER_DOWNLOAD` escape hatches.

Single file change (README.md).

## Pairs with

- [LambdatestIncPrivate/v16#446](https://github.com/LambdatestIncPrivate/v16/pull/446) — runtime Chrome gate (clean per-platform error if Chrome is missing at run time).
- [LambdaTest/homebrew-kane#3](https://github.com/LambdaTest/homebrew-kane/pull/3) — formula adds `depends_on cask: "google-chrome"` (brew auto-installs Chrome).

## Test plan

- [ ] README rendering on github.com/LambdaTest/kane-cli reads cleanly — Chrome section sits under Install, before "First run".
- [ ] Cross-references to v16#446 and homebrew-kane#3 are accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)