### PR TITLE
docs(testmd): clarify start-URL goes in step prose, add unknown-key troubleshooting (#73)

### DIFF
--- a/docs/user-guide/testmd/overview.md
+++ b/docs/user-guide/testmd/overview.md
@@ -286,12 +286,25 @@ Mistakes the parser catches before any browser launches:
 | `step config 'optional' must be boolean: got <type>` | `optional` was set to a non-boolean. |
 | `variable '<k>' must be a string or { value: ... } object` | A variable entry is the wrong shape. |
 | `auth/identity keys are CLI-only: <key>` | `username`, `access_key`, or another auth key appeared in frontmatter. |
-| `unknown config key: <key>` | A frontmatter or per-step key is not recognised. |
+| `unknown config key: <key>` | A frontmatter or per-step key is not recognised. See [Common key-name confusions](#common-key-name-confusions) below. |
 | `chrome config is global-only: <key>` | A Chrome-related key was set on an individual step. |
 | `'<key>' is run-level and cannot be set per-step` | `mode` or `on_lock_conflict` was set on an individual step. |
 | `step config on @import may only contain 'optional': got <key>` | An `@import` step's `yaml` block contains anything other than `optional`. |
 
 Parse errors abort the run before any browser launch, auth call, or upload. The exit code is `2`.
+
+### Common key-name confusions
+
+The frontmatter table is the single source of truth for the keys a `_test.md` file accepts. A few intuitive-sounding keys are **not** in that table and produce `unknown config key: <key>`. The right place for each:
+
+| Key you reached for | Where the value actually lives |
+|---|---|
+| `startUrl`, `url`, `baseUrl` | The first step's prose body. There is no frontmatter key for the start URL — the agent reads it from the step text, e.g. `## Open the app\nOpen https://example.com.`. The `target` frontmatter key looks similar but selects the **browser transport** (`chrome` / `cdp` / `ws`), not a URL. |
+| `name`, `title` | The file name (which is what `kane-cli testmd run` reports) and the per-step `## H2` headings. The optional `# Title` above the first step is decorative; the parser ignores anything before the first `## ` heading. |
+| `objective`, `description`, `goal` | The prose body of each step, directly under the `## H2` heading. The agent reads the step body as the objective. |
+| `auth`, `username`, `access_key`, `api_key` | CLI flags or your active profile, never frontmatter. Frontmatter rejects these with `auth/identity keys are CLI-only: <key>`. |
+
+If your error is `unknown config key:` and the key you tried isn't covered above, double-check it against the [frontmatter table](#frontmatter) — every accepted key is listed there.
 
 ## Next steps
 

--- a/docs/user-guide/testmd/overview.md
+++ b/docs/user-guide/testmd/overview.md
@@ -299,7 +299,7 @@ The frontmatter table is the single source of truth for the keys a `_test.md` fi
 
 | Key you reached for | Where the value actually lives |
 |---|---|
-| `startUrl`, `url`, `baseUrl` | The first step's prose body. There is no frontmatter key for the start URL — the agent reads it from the step text, e.g. `## Open the app\nOpen https://example.com.`. The `target` frontmatter key looks similar but selects the **browser transport** (`chrome` / `cdp` / `ws`), not a URL. |
+| `startUrl`, `url`, `baseUrl` | The first step's prose body. There is no frontmatter key for the start URL — the agent reads it from the step text, e.g. a step `## Open the app` whose body is `Open https://example.com.`. The `target` frontmatter key looks similar but selects the **browser transport** (`chrome` / `cdp` / `ws`), not a URL. |
 | `name`, `title` | The file name (which is what `kane-cli testmd run` reports) and the per-step `## H2` headings. The optional `# Title` above the first step is decorative; the parser ignores anything before the first `## ` heading. |
 | `objective`, `description`, `goal` | The prose body of each step, directly under the `## H2` heading. The agent reads the step body as the objective. |
 | `auth`, `username`, `access_key`, `api_key` | CLI flags or your active profile, never frontmatter. Frontmatter rejects these with `auth/identity keys are CLI-only: <key>`. |

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -12,6 +12,7 @@ This page lists common problems you may hit while using kane-cli, what causes th
 - [Run timed out or max steps exceeded](#run-timed-out-or-max-steps-exceeded)
 - [Variables not resolving](#variables-not-resolving)
 - [Upload failed or TMS error](#upload-failed-or-tms-error)
+- [testmd: unknown config key](#testmd-unknown-config-key)
 - [CLI exits with code 2 and no output](#cli-exits-with-code-2-and-no-output)
 - [Update available notice](#update-available-notice)
 - [Reporting bugs](#reporting-bugs)
@@ -167,6 +168,20 @@ kane-cli uploads run artifacts to TestmuAI TMS at the end of the session. If the
    ```
 
    If `project_id` is empty, set it with `kane-cli config project` or pick one in the TUI.
+
+## testmd: "unknown config key"
+
+If `kane-cli testmd run` aborts at parse time with:
+
+```
+error: [<file>:1] unknown config key: <key>
+```
+
+the key you put in the `--- ... ---` frontmatter block isn't one the parser accepts. Frontmatter has a fixed schema — see the [frontmatter table](./testmd/overview.md#frontmatter) for the complete list of valid keys.
+
+Common cases that trip people up — `name`, `objective`, `startUrl`, `url`, `description` — are not frontmatter keys at all. Each one belongs somewhere else in the file (file name, step heading, or step prose). The mapping is laid out in [Common key-name confusions](./testmd/overview.md#common-key-name-confusions).
+
+The exit code is `2`. No browser is launched and no upload is attempted, so it is safe to fix the key and re-run.
 
 ## CLI exits with code 2 and no output
 


### PR DESCRIPTION
## Summary

Fills the discoverability gap reported in #73: the user reached for intuitive frontmatter keys (`name`, `objective`, `startUrl`) and got `unknown config key: <key>` with no nearby pointer to where those values actually belong. The canonical [frontmatter table](https://github.com/LambdaTest/kane-cli/blob/main/docs/user-guide/testmd/overview.md#frontmatter) was already correct and exhaustive, so this PR adds two short pieces of signposting:

- **`docs/user-guide/testmd/overview.md` → new `### Common key-name confusions`** — placed directly under the "Common parse errors" table, and cross-linked from the `unknown config key:` row. Maps the four mental-model mismatches (`startUrl`/`url`/`baseUrl`, `name`/`title`, `objective`/`description`/`goal`, `auth`/`username`/`access_key`) to where the value actually lives. Importantly clarifies that the `target` key is the **browser transport** (`chrome` / `cdp` / `ws`), not a URL — so users don't end up making the inverse mistake after reading the table.
- **`docs/user-guide/troubleshooting.md` → new `## testmd: "unknown config key"` section** — surfaces the same mapping at the right user-journey moment (after a parse error, while the user is on troubleshooting.md). Cross-links to the canonical frontmatter table and to the new "Common key-name confusions" subsection.

Scope is intentionally narrow: this PR does not change the parser, the error message, or `--help` output. The maintainer comment on #73 ("we will add this in cli errors so anyone can look this up") indicates the runtime/error-message side will land separately and is owned by them.

## Test plan

- [x] Both files render correctly on GitHub (verified locally against the existing heading style, table syntax, and code-fence conventions in the same files).
- [x] All new internal anchors resolve:
  - `overview.md` → `#common-key-name-confusions` (target heading present)
  - `overview.md` → `#frontmatter` (existing target unchanged)
  - `troubleshooting.md` → `./testmd/overview.md#frontmatter`
  - `troubleshooting.md` → `./testmd/overview.md#common-key-name-confusions`
- [x] Contents list at the top of `troubleshooting.md` updated with the new entry; new entry slug `#testmd-unknown-config-key` matches GitHub's slugification of the heading (drops `"`, `:`, lowercases, hyphenates spaces).
- [x] No existing headings renamed, so inbound links from `README.md`, the rest of `docs/user-guide/`, and `troubleshooting.md`'s existing internal links continue to work.
- [x] All factual claims match the issue body and the existing `overview.md` frontmatter table (lines 79-95): `target` values are `chrome` / `cdp` / `ws`; `auth/identity keys are CLI-only` is the parser's actual error string; the optional `# Title` is decorative.
- [x] `CONTRIBUTING.md` scope: documentation improvements are explicitly in scope; code is not touched.

Refs: #73