### PR TITLE
docs+skills: 0.4.1 update — project/folder gate + generate mirror in Kiro

### DIFF
--- a/.agents/skills/kane-cli/SKILL.md
+++ b/.agents/skills/kane-cli/SKILL.md
@@ -55,7 +55,7 @@ Progress events have `step`/`status`/`remark` fields and **no `type` field**.
 #### What to skip
 
 - Individual passing steps — fold them into the overall progress line
-- Internal field names (`step`, `status`, `remark`, `run_end`, `final_state`, `bifurcation`, `session_dir`, etc.) — translate to plain language
+- Internal field names (`step`, `status`, `remark`, `run_end`, `final_state`, `bifurcation`, `session_dir`, `project_folder_auto_defaulted`, etc.) — translate to plain language. A `project_folder_auto_defaulted` event fires before progress when the run-startup gate auto-resolves a project/folder; surface it as one line ("kane-cli auto-selected project X / folder Y for this run") and move on. Details: `references/test-manager.md`.
 
 #### Example output for a 15-step run with one failure
 
@@ -138,6 +138,7 @@ When the user's request involves a browser — or writing test cases:
 - Multiple independent browser tasks → Read `references/parallel.md` first
 - Debug a failed run → Read `references/debug.md`
 - Configure kane-cli or check directory layout → Read `references/setup-and-config.md`
+- Browse / create / pick a Test Manager project or folder, or interpret the auto-default event → Read `references/test-manager.md`
 - You need the full NDJSON event schema (rare — §5's summary covers 90% of cases) → Read `references/parsing.md`
 
 **Every run, always:** follow §1 above.
@@ -149,6 +150,8 @@ When the user's request involves a browser — or writing test cases:
 ```bash
 kane-cli run "<objective>" --agent [options]
 ```
+
+> The `run` subcommand is **mandatory**. `kane-cli "<objective>"` (no `run`) does **not** work — unknown first tokens exit `2` with a "did you mean" suggestion. Same rule applies to `kane-cli testmd run …` and `kane-cli generate …`.
 
 `--agent` is mandatory — it switches stdout to NDJSON. Most-used flags:
 
@@ -233,7 +236,7 @@ Action → extraction → assertion in one objective:
 Stdout is NDJSON, one event per line. There are two shapes:
 
 - **Progress events** (most events) have `step` (1-based), `status` (`passed`/`failed`), `remark` — and **no `type` field**.
-- **Typed events** have a `type` field: `bifurcation`, `child_agent_start`, `child_agent_end`, `ask_user`, `error`, and finally `run_end`.
+- **Typed events** have a `type` field: `project_folder_auto_defaulted` (run-startup gate, fires before any progress when no project/folder is configured), `bifurcation`, `child_agent_start`, `child_agent_end`, `ask_user`, `error`, and finally `run_end`.
 
 Parsing strategy:
 
@@ -300,4 +303,5 @@ Internal event/field names (`generate_snapshot`, `request_id`, …) are for pars
 | Multiple independent browser tasks | `references/parallel.md` |
 | Need full NDJSON event schema (`run`) | `references/parsing.md` |
 | Need the `generate` NDJSON event schema | `references/generate-parsing.md` |
+| Browse / create projects or folders, or parse the auto-default event | `references/test-manager.md` |
 | First-time install, auth, or full config | `references/setup-and-config.md` |

--- a/.agents/skills/kane-cli/references/debug.md
+++ b/.agents/skills/kane-cli/references/debug.md
@@ -30,7 +30,9 @@ The `run_end` event provides `session_dir` and `run_dir` paths. Use those direct
 | 🔄 Agent repeats same action | Stuck in a loop / page didn't change | Rephrase objective, add explicit wait or assertion |
 | 🎯 Agent clicks wrong element | Ambiguous UI, multiple similar elements | Be more specific: "click the **blue** 'Submit' button in the **checkout form**" |
 | 👁️ Agent says done but didn't finish | Objective too vague | Add explicit assertions: "assert the confirmation page shows order number" |
-| 💀 Exit code 2, no steps | Auth or Chrome failure | Check `kane-cli whoami`, verify Chrome is available |
+| 💀 Exit code 2, no steps | Auth, TMS credential exchange, or Chrome failure | Check `kane-cli whoami`, verify Chrome is available |
+| ❓ Exit code 2 with "did you mean …" | Bare-objective shortcut — agent ran `kane-cli "<objective>"` without the `run` subcommand | Re-invoke as `kane-cli run "<objective>" --agent` (same rule for `testmd run` / `generate`) |
+| 📤 Upload silently fails after configuring a project/folder by hand | Saved ID is invalid (typo, deleted, no access) | No action needed — the next run detects the 4xx and auto-defaults a working project/folder. To rebind manually: `kane-cli config project` (TTY picker) or `kane-cli projects list` → `kane-cli config project <id>` (see `references/test-manager.md`) |
 | ⏱️ Exit code 3 | Timeout or cancelled | Increase `--timeout` or `--max-steps`, or split into smaller objectives |
 | 🚫 "CDP endpoint not reachable" | Chrome not running | Let kane-cli manage Chrome (remove `--cdp-endpoint`) |
 

--- a/.agents/skills/kane-cli/references/generate-parsing.md
+++ b/.agents/skills/kane-cli/references/generate-parsing.md
@@ -36,6 +36,7 @@ Shared with `run` (NOT generate-specific — don't treat as part of the generate
 
 | `type` | Fields | Meaning |
 |---|---|---|
+| `project_folder_auto_defaulted` | resolved project + folder (id, name) | Run-startup gate auto-resolved a project/folder when none was configured (or the cached one was stale/invalid). Fires before `generate_start`. Translate to plain language (see `references/test-manager.md`). |
 | `error` | `message` | A failure occurred; pair with the exit code to decide retry vs abort. |
 | `update_available` | `current`, `latest`, `severity` | A newer kane-cli exists. Informational; emitted before `generate_start`. |
 

--- a/.agents/skills/kane-cli/references/generate.md
+++ b/.agents/skills/kane-cli/references/generate.md
@@ -33,6 +33,8 @@ There is **no interactive session**. Each invocation runs exactly one generation
 | `--project <id>` / `--folder <id>` | Test Manager project / folder |
 | `--env prod\|stage` · `--username` / `--access-key` | Environment / auth (same as `run`) |
 
+If neither `--project`/`--folder` nor a saved project/folder is set when generation starts, kane-cli auto-resolves one headlessly and emits a `project_folder_auto_defaulted` event before `generate_start`. Translate it to a one-line note for the user — full handling lives in `references/test-manager.md`.
+
 ## Presenting a result (adaptive)
 
 The terminal data carries the full scenarios + cases. **Present it based on size**:

--- a/.agents/skills/kane-cli/references/parsing.md
+++ b/.agents/skills/kane-cli/references/parsing.md
@@ -28,6 +28,7 @@ These are **untyped** — they have no `type` field. Do **not** key on `event.ty
 
 | Event (`type` field) | Key Fields | Purpose |
 |-------|-----------|---------|
+| `project_folder_auto_defaulted` | resolved project + folder (id, name) | Run-startup gate auto-resolved a project/folder when none was configured (or the cached one was stale/invalid). Fires before any progress event on `run` / `testmd run` / `generate`. Translate to plain language (see `references/test-manager.md`). |
 | `bifurcation` | `flows[]`, `count` | Agent split objective into sub-flows |
 | `child_agent_start` | `child_id`, `objective`, `parent_step` | Child agent spawned |
 | `child_agent_end` | `child_id`, `success`, `steps_taken`, `summary` | Child agent finished |

--- a/.agents/skills/kane-cli/references/setup-and-config.md
+++ b/.agents/skills/kane-cli/references/setup-and-config.md
@@ -93,6 +93,8 @@ kane-cli config project <project-id>          # TMS project ID (or interactive p
 kane-cli config folder <folder-id>            # TMS folder ID (or interactive picker in TTY)
 ```
 
+> **Project / folder management — Read `references/test-manager.md`** for the full agent surface: `kane-cli projects list|create` and `kane-cli folders list|create` (with `--search` / `--limit` / `--offset` / `--description`), the NDJSON wire shape for `--agent` callers, and the `project_folder_auto_defaulted` event the run-startup gate emits when nothing is configured.
+
 ### Feedback
 
 Submit feedback on a completed test run:

--- a/.agents/skills/kane-cli/references/test-manager.md
+++ b/.agents/skills/kane-cli/references/test-manager.md
@@ -1,0 +1,141 @@
+<!-- Read this for the Test Manager (TMS) agent surface — what gets uploaded, where the run lands, the `projects` / `folders` subcommands and their NDJSON wire shape, and the run-startup auto-default event. Non-TTY surface only; the human config flow / interactive picker lives in the public user guide. -->
+
+# Test Manager Reference — Agent Surface
+
+Every kane-cli session uploads to a TestmuAI **Test Manager (TMS)** test case. The session lands inside a **project** (required) and optionally a **folder** inside that project. This page is the agent-facing surface for everything that touches TMS: where the run ends up, how to browse and create projects/folders programmatically, and the event the run-startup gate emits when nothing is configured.
+
+Field names below are for parsing only — translate to plain language for the user, per the §5 rule in `SKILL.md`.
+
+---
+
+## 1. Where a run lands
+
+After a successful upload, the terminal `run_end` event (`testmd_done` for `testmd run`) carries the dashboard link:
+
+```json
+{"type":"run_end","status":"passed", "test_url":"https://test-manager.lambdatest.com/projects/<id>/test-cases/<id>", ...}
+```
+
+For `testmd run`, the `test_md_summary` / `test_md_done` events also carry a `share_url` — a 7-day, no-login link suitable for CI artifacts.
+
+Surface `test_url` (and `share_url` when present) as a "View in Test Manager" line per the §1.4 results table in `SKILL.md`. Never paste raw URLs into the middle of a summary — they belong in the results table.
+
+---
+
+## 2. Projects & folders — selecting where uploads land
+
+Two ways an agent influences placement:
+
+- **Programmatically**, via the `projects` / `folders` subcommands (§3 + §4) — list, search, create, then persist with `kane-cli config project <id>` / `kane-cli config folder <id>`.
+- **Passively**, by observing the `project_folder_auto_defaulted` event the run-startup gate emits when nothing is configured (§5).
+
+In a non-TTY context (CI, pipes, every `--agent` caller), the no-arg form of `config project` / `config folder` will not prompt — always pass an explicit `<id>`. The interactive picker is the human-facing path and is documented in the user guide.
+
+---
+
+## 3. Listing — `projects list` / `folders list`
+
+```bash
+kane-cli projects list [--search <q>] [--limit <n>] [--offset <n>] --agent
+kane-cli folders  list [--search <q>] [--limit <n>] [--offset <n>] --agent
+```
+
+| Flag | Purpose |
+|---|---|
+| `--search <q>` | Filter by name (substring match). |
+| `--limit <n>` | Page size. Default is small (~10). Very large values are capped. |
+| `--offset <n>` | Skip the first N rows. |
+| `--agent` | Force NDJSON. Auto-on when stdout is piped/redirected, but pass it explicitly anyway. |
+
+`folders list` operates inside the currently configured project. If none is configured, list projects first or rely on §5.
+
+### Wire shape
+
+Each result line:
+
+```json
+{"id":"01J69X773TSY9TCHZY4VAT9VBH","name":"KaneAI Generated"}
+```
+
+Just `id` + `name`. The terminal line on every page:
+
+```json
+{"_meta":"page","limit":10,"offset":0,"returned":10,"has_more":true}
+```
+
+| Field | Meaning |
+|---|---|
+| `_meta: "page"` | Discriminator — distinguishes pagination metadata from a result row. Skip when collecting results. |
+| `limit` / `offset` | Echoed from the request. |
+| `returned` | Number of result rows on this page (≤ `limit`). |
+| `has_more` | `true` if another page exists. There is no `total` — only a "more remaining" signal, so don't promise an exact count to the user. |
+
+### Pagination idiom
+
+```bash
+offset=0; limit=10
+while :; do
+  page=$(kane-cli projects list --limit "$limit" --offset "$offset" --agent)
+  echo "$page" | jq -c 'select(._meta != "page")'    # result rows
+  more=$(echo "$page" | jq -r 'select(._meta == "page") | .has_more')
+  [ "$more" = "true" ] || break
+  offset=$((offset + limit))
+done
+```
+
+Same pattern for `folders list`.
+
+---
+
+## 4. Creating — `projects create` / `folders create`
+
+```bash
+kane-cli projects create "<name>" [--description "<text>"] --agent
+kane-cli folders  create "<name>" [--description "<text>"] --agent
+```
+
+NDJSON: one line describing the new id + name. `folders create` files the folder inside the currently configured project.
+
+To use the result for subsequent runs, persist with `kane-cli config project <id>` / `kane-cli config folder <id>` — non-interactive when called with an explicit `<id>`.
+
+---
+
+## 5. The run-startup auto-default event
+
+`kane-cli run`, `kane-cli testmd run`, and `kane-cli generate` all validate the cached project/folder before launching anything. Three outcomes:
+
+1. **Cached project/folder still valid** → run proceeds. No event.
+2. **Nothing configured, or the cached IDs are gone / inaccessible** → kane-cli resolves a sensible project/folder headlessly (find-or-create), then emits a typed event before the run starts:
+
+   ```
+   {"type": "project_folder_auto_defaulted", ...}
+   ```
+
+   The event carries the resolved project + folder so the caller knows what was picked. Translate it for the human user — for example:
+
+   > kane-cli auto-selected project **<name>** / folder **<name>** for this run.
+
+   Don't surface raw field names.
+
+3. **No usable credentials in a non-TTY context** → exit code `2` with an auth/setup error.
+
+### Self-healing for stale IDs
+
+If a previously-configured project/folder becomes unusable (deleted, renamed, access revoked, or a typo was saved as the ID), TMS returns a `4xx` for the validation call and the gate treats both as **missing** — it clears the stale value and re-resolves via auto-default. The run is not aborted for this.
+
+Transient validation failures (`5xx`, network, timeout) are treated as **error** and the gate fails open with the cached IDs so brief upstream hiccups don't block a run.
+
+### When you see the event
+
+Surface it as a one-line note, then continue parsing the run normally. If the user wants their runs in a different project, point them at the user guide's project/folder configuration page — the public `kane-cli config project [<id>]` / `kane-cli config folder [<id>]` commands cover the human flow.
+
+---
+
+## 6. Exit codes (TMS subcommands only)
+
+| Code | Meaning |
+|---|---|
+| 0 | OK |
+| 2 | Auth/setup error (missing or invalid credentials) or unknown subcommand |
+
+Other codes are run-specific (`run` / `testmd run` / `generate`) and don't apply to `projects` / `folders`.

--- a/.agents/skills/kane-cli/references/testmd.md
+++ b/.agents/skills/kane-cli/references/testmd.md
@@ -44,6 +44,8 @@ Run it:
 kane-cli testmd run amazon_test.md --agent
 ```
 
+> Before the test launches, kane-cli validates the cached project/folder. If none is configured (or the cached one is stale/invalid), the run-startup gate auto-defaults a project/folder and emits a `project_folder_auto_defaulted` event on stdout. Surface it as a one-line note for the user and keep parsing — full handling lives in `references/test-manager.md`.
+
 ## File format
 
 Four parts in order:

--- a/.claude/skills/kane-cli/SKILL.md
+++ b/.claude/skills/kane-cli/SKILL.md
@@ -55,7 +55,7 @@ Progress events have `step`/`status`/`remark` fields and **no `type` field**.
 #### What to skip
 
 - Individual passing steps — fold them into the overall progress line
-- Internal field names (`step`, `status`, `remark`, `run_end`, `final_state`, `bifurcation`, `session_dir`, etc.) — translate to plain language
+- Internal field names (`step`, `status`, `remark`, `run_end`, `final_state`, `bifurcation`, `session_dir`, `project_folder_auto_defaulted`, etc.) — translate to plain language. A `project_folder_auto_defaulted` event fires before progress when the run-startup gate auto-resolves a project/folder; surface it as one line ("kane-cli auto-selected project X / folder Y for this run") and move on. Details: `references/test-manager.md`.
 
 #### Example output for a 15-step run with one failure
 
@@ -138,6 +138,7 @@ When the user's request involves a browser — or writing test cases:
 - Multiple independent browser tasks → Read `references/parallel.md` first
 - Debug a failed run → Read `references/debug.md`
 - Configure kane-cli or check directory layout → Read `references/setup-and-config.md`
+- Browse / create / pick a Test Manager project or folder, or interpret the auto-default event → Read `references/test-manager.md`
 - You need the full NDJSON event schema (rare — §5's summary covers 90% of cases) → Read `references/parsing.md`
 
 **Every run, always:** follow §1 above.
@@ -149,6 +150,8 @@ When the user's request involves a browser — or writing test cases:
 ```bash
 kane-cli run "<objective>" --agent [options]
 ```
+
+> The `run` subcommand is **mandatory**. `kane-cli "<objective>"` (no `run`) does **not** work — unknown first tokens exit `2` with a "did you mean" suggestion. Same rule applies to `kane-cli testmd run …` and `kane-cli generate …`.
 
 `--agent` is mandatory — it switches stdout to NDJSON. Most-used flags:
 
@@ -233,7 +236,7 @@ Action → extraction → assertion in one objective:
 Stdout is NDJSON, one event per line. There are two shapes:
 
 - **Progress events** (most events) have `step` (1-based), `status` (`passed`/`failed`), `remark` — and **no `type` field**.
-- **Typed events** have a `type` field: `bifurcation`, `child_agent_start`, `child_agent_end`, `ask_user`, `error`, and finally `run_end`.
+- **Typed events** have a `type` field: `project_folder_auto_defaulted` (run-startup gate, fires before any progress when no project/folder is configured), `bifurcation`, `child_agent_start`, `child_agent_end`, `ask_user`, `error`, and finally `run_end`.
 
 Parsing strategy:
 
@@ -300,4 +303,5 @@ Internal event/field names (`generate_snapshot`, `request_id`, …) are for pars
 | Multiple independent browser tasks | `references/parallel.md` |
 | Need full NDJSON event schema (`run`) | `references/parsing.md` |
 | Need the `generate` NDJSON event schema | `references/generate-parsing.md` |
+| Browse / create projects or folders, or parse the auto-default event | `references/test-manager.md` |
 | First-time install, auth, or full config | `references/setup-and-config.md` |

--- a/.claude/skills/kane-cli/references/debug.md
+++ b/.claude/skills/kane-cli/references/debug.md
@@ -30,7 +30,9 @@ The `run_end` event provides `session_dir` and `run_dir` paths. Use those direct
 | 🔄 Agent repeats same action | Stuck in a loop / page didn't change | Rephrase objective, add explicit wait or assertion |
 | 🎯 Agent clicks wrong element | Ambiguous UI, multiple similar elements | Be more specific: "click the **blue** 'Submit' button in the **checkout form**" |
 | 👁️ Agent says done but didn't finish | Objective too vague | Add explicit assertions: "assert the confirmation page shows order number" |
-| 💀 Exit code 2, no steps | Auth or Chrome failure | Check `kane-cli whoami`, verify Chrome is available |
+| 💀 Exit code 2, no steps | Auth, TMS credential exchange, or Chrome failure | Check `kane-cli whoami`, verify Chrome is available |
+| ❓ Exit code 2 with "did you mean …" | Bare-objective shortcut — agent ran `kane-cli "<objective>"` without the `run` subcommand | Re-invoke as `kane-cli run "<objective>" --agent` (same rule for `testmd run` / `generate`) |
+| 📤 Upload silently fails after configuring a project/folder by hand | Saved ID is invalid (typo, deleted, no access) | No action needed — the next run detects the 4xx and auto-defaults a working project/folder. To rebind manually: `kane-cli config project` (TTY picker) or `kane-cli projects list` → `kane-cli config project <id>` (see `references/test-manager.md`) |
 | ⏱️ Exit code 3 | Timeout or cancelled | Increase `--timeout` or `--max-steps`, or split into smaller objectives |
 | 🚫 "CDP endpoint not reachable" | Chrome not running | Let kane-cli manage Chrome (remove `--cdp-endpoint`) |
 

--- a/.claude/skills/kane-cli/references/generate-parsing.md
+++ b/.claude/skills/kane-cli/references/generate-parsing.md
@@ -36,6 +36,7 @@ Shared with `run` (NOT generate-specific — don't treat as part of the generate
 
 | `type` | Fields | Meaning |
 |---|---|---|
+| `project_folder_auto_defaulted` | resolved project + folder (id, name) | Run-startup gate auto-resolved a project/folder when none was configured (or the cached one was stale/invalid). Fires before `generate_start`. Translate to plain language (see `references/test-manager.md`). |
 | `error` | `message` | A failure occurred; pair with the exit code to decide retry vs abort. |
 | `update_available` | `current`, `latest`, `severity` | A newer kane-cli exists. Informational; emitted before `generate_start`. |
 

--- a/.claude/skills/kane-cli/references/generate.md
+++ b/.claude/skills/kane-cli/references/generate.md
@@ -33,6 +33,8 @@ There is **no interactive session**. Each invocation runs exactly one generation
 | `--project <id>` / `--folder <id>` | Test Manager project / folder |
 | `--env prod\|stage` · `--username` / `--access-key` | Environment / auth (same as `run`) |
 
+If neither `--project`/`--folder` nor a saved project/folder is set when generation starts, kane-cli auto-resolves one headlessly and emits a `project_folder_auto_defaulted` event before `generate_start`. Translate it to a one-line note for the user — full handling lives in `references/test-manager.md`.
+
 ## Presenting a result (adaptive)
 
 The terminal data carries the full scenarios + cases. **Present it based on size**:

--- a/.claude/skills/kane-cli/references/parsing.md
+++ b/.claude/skills/kane-cli/references/parsing.md
@@ -28,6 +28,7 @@ These are **untyped** — they have no `type` field. Do **not** key on `event.ty
 
 | Event (`type` field) | Key Fields | Purpose |
 |-------|-----------|---------|
+| `project_folder_auto_defaulted` | resolved project + folder (id, name) | Run-startup gate auto-resolved a project/folder when none was configured (or the cached one was stale/invalid). Fires before any progress event on `run` / `testmd run` / `generate`. Translate to plain language (see `references/test-manager.md`). |
 | `bifurcation` | `flows[]`, `count` | Agent split objective into sub-flows |
 | `child_agent_start` | `child_id`, `objective`, `parent_step` | Child agent spawned |
 | `child_agent_end` | `child_id`, `success`, `steps_taken`, `summary` | Child agent finished |

--- a/.claude/skills/kane-cli/references/setup-and-config.md
+++ b/.claude/skills/kane-cli/references/setup-and-config.md
@@ -93,6 +93,8 @@ kane-cli config project <project-id>          # TMS project ID (or interactive p
 kane-cli config folder <folder-id>            # TMS folder ID (or interactive picker in TTY)
 ```
 
+> **Project / folder management — Read `references/test-manager.md`** for the full agent surface: `kane-cli projects list|create` and `kane-cli folders list|create` (with `--search` / `--limit` / `--offset` / `--description`), the NDJSON wire shape for `--agent` callers, and the `project_folder_auto_defaulted` event the run-startup gate emits when nothing is configured.
+
 ### Feedback
 
 Submit feedback on a completed test run:

--- a/.claude/skills/kane-cli/references/test-manager.md
+++ b/.claude/skills/kane-cli/references/test-manager.md
@@ -1,0 +1,141 @@
+<!-- Read this for the Test Manager (TMS) agent surface — what gets uploaded, where the run lands, the `projects` / `folders` subcommands and their NDJSON wire shape, and the run-startup auto-default event. Non-TTY surface only; the human config flow / interactive picker lives in the public user guide. -->
+
+# Test Manager Reference — Agent Surface
+
+Every kane-cli session uploads to a TestmuAI **Test Manager (TMS)** test case. The session lands inside a **project** (required) and optionally a **folder** inside that project. This page is the agent-facing surface for everything that touches TMS: where the run ends up, how to browse and create projects/folders programmatically, and the event the run-startup gate emits when nothing is configured.
+
+Field names below are for parsing only — translate to plain language for the user, per the §5 rule in `SKILL.md`.
+
+---
+
+## 1. Where a run lands
+
+After a successful upload, the terminal `run_end` event (`testmd_done` for `testmd run`) carries the dashboard link:
+
+```json
+{"type":"run_end","status":"passed", "test_url":"https://test-manager.lambdatest.com/projects/<id>/test-cases/<id>", ...}
+```
+
+For `testmd run`, the `test_md_summary` / `test_md_done` events also carry a `share_url` — a 7-day, no-login link suitable for CI artifacts.
+
+Surface `test_url` (and `share_url` when present) as a "View in Test Manager" line per the §1.4 results table in `SKILL.md`. Never paste raw URLs into the middle of a summary — they belong in the results table.
+
+---
+
+## 2. Projects & folders — selecting where uploads land
+
+Two ways an agent influences placement:
+
+- **Programmatically**, via the `projects` / `folders` subcommands (§3 + §4) — list, search, create, then persist with `kane-cli config project <id>` / `kane-cli config folder <id>`.
+- **Passively**, by observing the `project_folder_auto_defaulted` event the run-startup gate emits when nothing is configured (§5).
+
+In a non-TTY context (CI, pipes, every `--agent` caller), the no-arg form of `config project` / `config folder` will not prompt — always pass an explicit `<id>`. The interactive picker is the human-facing path and is documented in the user guide.
+
+---
+
+## 3. Listing — `projects list` / `folders list`
+
+```bash
+kane-cli projects list [--search <q>] [--limit <n>] [--offset <n>] --agent
+kane-cli folders  list [--search <q>] [--limit <n>] [--offset <n>] --agent
+```
+
+| Flag | Purpose |
+|---|---|
+| `--search <q>` | Filter by name (substring match). |
+| `--limit <n>` | Page size. Default is small (~10). Very large values are capped. |
+| `--offset <n>` | Skip the first N rows. |
+| `--agent` | Force NDJSON. Auto-on when stdout is piped/redirected, but pass it explicitly anyway. |
+
+`folders list` operates inside the currently configured project. If none is configured, list projects first or rely on §5.
+
+### Wire shape
+
+Each result line:
+
+```json
+{"id":"01J69X773TSY9TCHZY4VAT9VBH","name":"KaneAI Generated"}
+```
+
+Just `id` + `name`. The terminal line on every page:
+
+```json
+{"_meta":"page","limit":10,"offset":0,"returned":10,"has_more":true}
+```
+
+| Field | Meaning |
+|---|---|
+| `_meta: "page"` | Discriminator — distinguishes pagination metadata from a result row. Skip when collecting results. |
+| `limit` / `offset` | Echoed from the request. |
+| `returned` | Number of result rows on this page (≤ `limit`). |
+| `has_more` | `true` if another page exists. There is no `total` — only a "more remaining" signal, so don't promise an exact count to the user. |
+
+### Pagination idiom
+
+```bash
+offset=0; limit=10
+while :; do
+  page=$(kane-cli projects list --limit "$limit" --offset "$offset" --agent)
+  echo "$page" | jq -c 'select(._meta != "page")'    # result rows
+  more=$(echo "$page" | jq -r 'select(._meta == "page") | .has_more')
+  [ "$more" = "true" ] || break
+  offset=$((offset + limit))
+done
+```
+
+Same pattern for `folders list`.
+
+---
+
+## 4. Creating — `projects create` / `folders create`
+
+```bash
+kane-cli projects create "<name>" [--description "<text>"] --agent
+kane-cli folders  create "<name>" [--description "<text>"] --agent
+```
+
+NDJSON: one line describing the new id + name. `folders create` files the folder inside the currently configured project.
+
+To use the result for subsequent runs, persist with `kane-cli config project <id>` / `kane-cli config folder <id>` — non-interactive when called with an explicit `<id>`.
+
+---
+
+## 5. The run-startup auto-default event
+
+`kane-cli run`, `kane-cli testmd run`, and `kane-cli generate` all validate the cached project/folder before launching anything. Three outcomes:
+
+1. **Cached project/folder still valid** → run proceeds. No event.
+2. **Nothing configured, or the cached IDs are gone / inaccessible** → kane-cli resolves a sensible project/folder headlessly (find-or-create), then emits a typed event before the run starts:
+
+   ```
+   {"type": "project_folder_auto_defaulted", ...}
+   ```
+
+   The event carries the resolved project + folder so the caller knows what was picked. Translate it for the human user — for example:
+
+   > kane-cli auto-selected project **<name>** / folder **<name>** for this run.
+
+   Don't surface raw field names.
+
+3. **No usable credentials in a non-TTY context** → exit code `2` with an auth/setup error.
+
+### Self-healing for stale IDs
+
+If a previously-configured project/folder becomes unusable (deleted, renamed, access revoked, or a typo was saved as the ID), TMS returns a `4xx` for the validation call and the gate treats both as **missing** — it clears the stale value and re-resolves via auto-default. The run is not aborted for this.
+
+Transient validation failures (`5xx`, network, timeout) are treated as **error** and the gate fails open with the cached IDs so brief upstream hiccups don't block a run.
+
+### When you see the event
+
+Surface it as a one-line note, then continue parsing the run normally. If the user wants their runs in a different project, point them at the user guide's project/folder configuration page — the public `kane-cli config project [<id>]` / `kane-cli config folder [<id>]` commands cover the human flow.
+
+---
+
+## 6. Exit codes (TMS subcommands only)
+
+| Code | Meaning |
+|---|---|
+| 0 | OK |
+| 2 | Auth/setup error (missing or invalid credentials) or unknown subcommand |
+
+Other codes are run-specific (`run` / `testmd run` / `generate`) and don't apply to `projects` / `folders`.

--- a/.claude/skills/kane-cli/references/testmd.md
+++ b/.claude/skills/kane-cli/references/testmd.md
@@ -44,6 +44,8 @@ Run it:
 kane-cli testmd run amazon_test.md --agent
 ```
 
+> Before the test launches, kane-cli validates the cached project/folder. If none is configured (or the cached one is stale/invalid), the run-startup gate auto-defaults a project/folder and emits a `project_folder_auto_defaulted` event on stdout. Surface it as a one-line note for the user and keep parsing — full handling lives in `references/test-manager.md`.
+
 ## File format
 
 Four parts in order:

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh
   - [Installation](docs/user-guide/installation.md) · [Getting started](docs/user-guide/getting-started.md) · [Authentication](docs/user-guide/authentication.md)
   - [Running tests](docs/user-guide/running-tests.md) · [Configuration](docs/user-guide/configuration.md) · [Variables & context](docs/user-guide/variables-and-context.md)
   - test.md files: [overview](docs/user-guide/testmd/overview.md) · [running](docs/user-guide/testmd/running.md) · [composition](docs/user-guide/testmd/composition.md)
-  - [TMS integration](docs/user-guide/tms-integration.md) · [CI/CD recipes](docs/user-guide/cicd.md) · [Troubleshooting](docs/user-guide/troubleshooting.md)
+  - [Test Manager integration](docs/user-guide/test-manager-integration.md) · [CI/CD recipes](docs/user-guide/cicd.md) · [Troubleshooting](docs/user-guide/troubleshooting.md)
 - **Agent setup guide** (deep reference for AI coding agents): [testmuai.com/kane-cli/agents.md](https://testmuai.com/kane-cli/agents.md)
 - **Issues / bug reports:** [GitHub Issues](https://github.com/LambdaTest/kane-cli/issues/new/choose)
 - **Security:** see [SECURITY.md](SECURITY.md)

--- a/docs/user-guide/cicd.md
+++ b/docs/user-guide/cicd.md
@@ -10,6 +10,7 @@ These patterns apply to every CI system; the recipes below differ only in how th
 - Always pass `--timeout <seconds>`. A hung run cannot be allowed to block the pipeline.
 - Authenticate with `--username` and `--access-key` from CI secrets. Do not call `kane-cli login` in CI — that flow opens a browser for OAuth and will not work on a runner.
 - Load test data with `--variables-file <path>`. Check the file into your repo (without secret values), or generate it before the step.
+- **Project and folder are optional.** If you want uploads filed under a specific Test Manager project/folder, pre-configure with `kane-cli config project <id>` / `kane-cli config folder <id>` (use `kane-cli projects list` / `kane-cli folders list` to find the IDs). If you skip this, kane-cli auto-defaults a project/folder on first run and reports which one it picked — see [test-manager-integration.md](./test-manager-integration.md).
 - Check the exit code. The mapping is documented in [running tests](./running-tests.md#exit-codes); the short form is `0` passed, `1` failed, `2` error, `3` timeout or cancellation.
 
 The runner spawns Chrome itself, so the CI image must have Chrome available on `PATH`. If your runner image cannot install Chrome, point kane-cli at a remote browser with `--cdp-endpoint <url>` or `--ws-endpoint <url>` (for example, a TestmuAI `wss://` endpoint).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -76,7 +76,7 @@ In TUI mode, the same setting can be edited through an interactive window-size p
 kane-cli config project
 ```
 
-In a TTY, this opens an interactive project picker. The picker fetches the projects available to your active profile, lets you search and arrow-key through them, and saves the chosen `project_id` and `project_name`. Login is required before the picker can fetch projects.
+In a TTY, this opens an interactive project picker. The picker fetches the projects available to your active profile, lets you search and arrow-key through them, and saves the chosen `project_id` and `project_name`. Either OAuth or basic-auth credentials are sufficient — you no longer have to also store a username/access-key pair to use the picker.
 
 You can also set a project ID directly without the picker:
 
@@ -84,7 +84,9 @@ You can also set a project ID directly without the picker:
 kane-cli config project <project-id>
 ```
 
-See [tms-integration.md](./tms-integration.md) for how project selection feeds into uploads.
+In a non-interactive shell (CI, pipes), pass an explicit `<project-id>`. To discover the right ID first, use `kane-cli projects list` (see [test-manager-integration.md](./test-manager-integration.md)).
+
+If you don't configure a project at all, kane-cli auto-resolves a sensible default when the first run starts — see "Auto-default on first run" in [test-manager-integration.md](./test-manager-integration.md).
 
 ### TMS folder
 
@@ -92,7 +94,7 @@ See [tms-integration.md](./tms-integration.md) for how project selection feeds i
 kane-cli config folder
 ```
 
-Opens an interactive folder picker for the currently selected project. Folders are searchable and shown with their hierarchy. The picker writes both `folder_id` and `folder_name`. You must have a project selected first.
+Opens an interactive folder picker for the currently selected project. Folders are searchable and shown with their hierarchy. The picker writes both `folder_id` and `folder_name`. You must have a project selected first. OAuth and basic-auth profiles are both supported.
 
 To set a folder ID without the picker:
 
@@ -100,7 +102,11 @@ To set a folder ID without the picker:
 kane-cli config folder <folder-id>
 ```
 
-See [tms-integration.md](./tms-integration.md) for how folder selection feeds into uploads.
+For scripted discovery in non-TTY contexts, use `kane-cli folders list` — see [test-manager-integration.md](./test-manager-integration.md).
+
+### Self-healing for stale IDs
+
+If a previously-configured project or folder later becomes unusable (deleted, renamed, you lost access, or you typed an invalid ID by accident), kane-cli detects the bad ID on the next run, clears it, and auto-resolves a new default instead of letting the run proceed with a dead value and silently failing the upload. To rebind explicitly, run `kane-cli config project` again (or `kane-cli projects list` followed by `kane-cli config project <id>`).
 
 ### Mode
 
@@ -126,7 +132,7 @@ The `code_export` block enables and configures generated code output that is pro
   - `--code-language <lang>` to pick the output language (only `python` is supported today).
   - `--skip-code-validation` / `--no-skip-code-validation` to control post-codegen worker-side validation.
 
-Code export requires a TMS upload to run, so it is only meaningful when `mode` is `testing` and a project/folder are configured. See [tms-integration.md](./tms-integration.md) for the full upload pipeline.
+Code export requires a TMS upload to run, so it is only meaningful when `mode` is `testing` and a project/folder are configured (or auto-defaulted). See [test-manager-integration.md](./test-manager-integration.md) for the full upload pipeline.
 
 ## Chrome management
 

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -70,7 +70,7 @@ By default each run starts on the KaneAI playground site. The agent navigates fr
 
 ## What happens at the end of a run
 
-When the session ends, kane-cli uploads the run to TestmuAI Test Manager and prints a share link. For details on the upload, the share-link experience, and the run mode toggle, see [tms-integration](./tms-integration.md). To change settings like window size, Chrome profile, or the active project and folder, see [configuration](./configuration.md).
+When the session ends, kane-cli uploads the run to TestmuAI Test Manager and prints a share link. For details on the upload, the share-link experience, and the run mode toggle, see [test-manager-integration](./test-manager-integration.md). To change settings like window size, Chrome profile, or the active project and folder, see [configuration](./configuration.md).
 
 ## Next steps
 

--- a/docs/user-guide/running-tests.md
+++ b/docs/user-guide/running-tests.md
@@ -195,7 +195,7 @@ When stdin is not a TTY, kane-cli automatically switches to plain NDJSON mode (t
 |------|---------|
 | `0` | Run passed. |
 | `1` | Run failed (agent reached an unrecoverable failure or upload failed). |
-| `2` | Error (auth, configuration, Chrome, or unhandled exception). |
+| `2` | Error (auth, TMS credential exchange, configuration, Chrome, unknown subcommand, or unhandled exception). |
 | `3` | Run was cancelled or hit the `--timeout`. |
 
 Use these codes to gate downstream CI steps.

--- a/docs/user-guide/running-tests.md
+++ b/docs/user-guide/running-tests.md
@@ -221,8 +221,8 @@ Below the summary, kane-cli prints any of the following links that apply to the 
 | `TestCase` | The test case detail page in TestmuAI TMS. |
 | `CodeExport` | The local directory containing the generated code (when code export is enabled). |
 
-Modern terminals render these as clickable hyperlinks. For details on what each link leads to, see [./tms-integration.md](./tms-integration.md).
+Modern terminals render these as clickable hyperlinks. For details on what each link leads to, see [./test-manager-integration.md](./test-manager-integration.md).
 
 ## Feedback prompt
 
-After the result and links print, kane-cli prompts you to rate the session with thumbs up or thumbs down. Use the left and right arrow keys to choose, Enter to submit, or Esc to skip. The rating is sent to TestmuAI TMS for the active test case; see [./tms-integration.md](./tms-integration.md) for what is recorded.
+After the result and links print, kane-cli prompts you to rate the session with thumbs up or thumbs down. Use the left and right arrow keys to choose, Enter to submit, or Esc to skip. The rating is sent to TestmuAI TMS for the active test case; see [./test-manager-integration.md](./test-manager-integration.md) for what is recorded.

--- a/docs/user-guide/test-manager-integration.md
+++ b/docs/user-guide/test-manager-integration.md
@@ -17,7 +17,7 @@ If the upload fails, kane-cli prints the error and exits. The local session dire
 
 ## Choosing where uploads land
 
-Each test case is filed under a Test Manager project. Optionally, you can also choose a folder inside that project.
+Each test case is filed under a Test Manager project. Optionally, you can also choose a folder inside that project. You can configure either explicitly, list and create from the command line, or let kane-cli auto-default one for you on first run.
 
 ### Project
 
@@ -27,7 +27,7 @@ Configure your project once, and every subsequent session uploads under it.
 kane-cli config project
 ```
 
-With no value, this opens a search-as-you-type picker. Projects are loaded from your Test Manager account on demand. Type to filter, use the arrow keys to navigate pages of five, press `Enter` to select, or `Tab` to create a new project. If your account has no projects yet, the picker jumps straight to the create flow.
+With no value, this opens a search-as-you-type picker. Projects are loaded from your Test Manager account on demand. Type to filter, use the arrow keys to navigate pages, press `Enter` to select, or `Tab` to create a new project. If your account has no projects yet, the picker jumps straight to the create flow. The picker works with either OAuth or basic-auth credentials.
 
 You can also set a project non-interactively by ID:
 
@@ -53,9 +53,33 @@ kane-cli config folder <folder-id>
 
 If you try to set a folder before choosing a project, kane-cli asks you to pick a project first.
 
+### Browse and create from the command line
+
+For scripts, CI, and any non-interactive shell where the picker is not appropriate, kane-cli exposes the same data as commands:
+
+```bash
+kane-cli projects list [--search <q>] [--limit <n>] [--offset <n>]
+kane-cli projects create "<name>" [--description "<text>"]
+
+kane-cli folders list  [--search <q>] [--limit <n>] [--offset <n>]
+kane-cli folders create "<name>" [--description "<text>"]
+```
+
+In a TTY, list commands render a paginated table. When stdout is piped or redirected — or when `--agent` is passed — the output switches to NDJSON, one JSON object per line, terminated by a small pagination summary. Use `--search` to filter by name on the server, and `--limit` / `--offset` to page through results.
+
+`folders list` and `folders create` operate inside the currently configured project, so set a project before calling them.
+
+After creating, persist the new id with `kane-cli config project <id>` or `kane-cli config folder <id>` so subsequent runs upload there.
+
+### Auto-default on first run
+
+If you launch a run without ever configuring a project or folder, kane-cli auto-resolves a sensible default at run start — find-or-create against your account — and tells you which one it picked. The same fallback fires for `kane-cli testmd run` and `kane-cli generate`. You don't have to pre-configure anything for the first run to succeed.
+
+The same auto-default kicks in if a previously-configured project or folder has been deleted, renamed, or revoked, or if you set an invalid ID by hand (for example, a typo). kane-cli detects the bad ID, clears it, and resolves a working default rather than letting the run proceed and silently failing the upload at the end. To rebind explicitly, run `kane-cli config project` (or `kane-cli projects list` followed by `kane-cli config project <id>`).
+
 ### Finding your test case in Test Manager
 
-After a successful upload, kane-cli prints two links to the terminal (see [Share links at session exit](#share-links-at-session-exit)). Both lead into the TestmuAI Test Manager UI for the test case that was just created. From there you can browse the project and folder you configured, view the run summary, and dig into individual steps and screenshots.
+After a successful upload, kane-cli prints two links to the terminal (see [Share links at session exit](#share-links-at-session-exit)). Both lead into the TestmuAI Test Manager UI for the test case that was just created. From there you can browse the project and folder you configured (or that were auto-defaulted), view the run summary, and dig into individual steps and screenshots.
 
 ## Code export
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -160,13 +160,7 @@ kane-cli uploads run artifacts to TestmuAI TMS at the end of the session. If the
 
 1. **Authentication.** Re-check `kane-cli whoami` and re-login if needed. TMS upload requires a valid token (or basic auth) for the configured environment.
 2. **Network connectivity.** The upload talks to the TestmuAI control plane and a cloud storage endpoint. Verify outbound HTTPS to your environment's TestmuAI hosts is not blocked by a proxy or firewall.
-3. **Project is set.** The pipeline will not commit a test case without a project. Confirm one is configured:
-
-   ```bash
-   kane-cli config show
-   ```
-
-   If `project_id` is empty, set it with `kane-cli config project` or pick one in the TUI.
+3. **Project / folder.** If `kane-cli config show` reports `project_id` empty, you don't need to do anything — kane-cli auto-defaults a project on first run. If you want uploads in a specific project or folder, set it explicitly with `kane-cli config project <id>` / `kane-cli config folder <id>` (use `kane-cli projects list` / `kane-cli folders list` to discover IDs), or pick one in the TUI. A previously-configured project that has been deleted or renamed is detected automatically and replaced via auto-default; an invalid ID typed by mistake is handled the same way. See [test-manager-integration.md](./test-manager-integration.md) for the full behavior.
 
 ## CLI exits with code 2 and no output
 

--- a/integrations/docs/kiro-powers.md
+++ b/integrations/docs/kiro-powers.md
@@ -15,30 +15,35 @@ The `integrations/kiro-powers/` folder is a [Kiro power](https://kiro.dev/docs/p
 | Artifact | Path | Purpose |
 |---|---|---|
 | **Canonical skill** | `skill-installer/skills/SKILL.md` | Source of every CLI fact: command shapes, flags, exit codes, NDJSON essentials, decision tree, results presentation. **Edit this first.** Every other integration mirrors from here. |
-| **Canonical references** | `skill-installer/skills/references/*.md` | On-demand reference content: `objectives-cookbook.md` (pattern catalog + checkpoint analyze methods), `testmd.md` (file format, replay), `parsing.md` (full NDJSON schema), `debug.md` (log layout), `parallel.md`, `setup-and-config.md`. Equally authoritative — facts in any of these must mirror through. |
+| **Canonical references** | `skill-installer/skills/references/*.md` | On-demand reference content: `objectives-cookbook.md` (pattern catalog + checkpoint analyze methods), `testmd.md` (file format, replay), `generate.md` + `generate-parsing.md` (AI test-case authoring), `test-manager.md` (project/folder agent surface + auto-default event), `parsing.md` (full NDJSON schema), `debug.md` (log layout), `parallel.md`, `setup-and-config.md`. Equally authoritative — facts in any of these must mirror through. |
 | Kiro power root | `integrations/kiro-powers/POWER.md` | Frontmatter (name/displayName/keywords/author), onboarding, condensed command reference, steering-file mapping. |
-| `kane-cli run` steering | `integrations/kiro-powers/steering/kane-cli-run.md` | Full reference for one-shot `kane-cli run`: objective patterns + checkpoint analyze methods (Visual / Textual-DOM / URL / Title / DevTools→Network/Console/Performance/Cookies/localStorage), full flag table, NDJSON parsing, results presentation, failure diagnosis, parallel execution. |
-| `kane-cli testmd` steering | `integrations/kiro-powers/steering/kane-cli-testmd.md` | Full reference for `kane-cli testmd`: file format, frontmatter, `@import`, replay/author cache, `Result.md`, CI patterns, parse errors. |
+| `kane-cli run` steering | `integrations/kiro-powers/steering/kane-cli-run.md` | Full reference for one-shot `kane-cli run`: objective patterns + checkpoint analyze methods (Visual / Textual-DOM / URL / Title / DevTools→Network/Console/Performance/Cookies/localStorage), full flag table, NDJSON parsing (including `project_folder_auto_defaulted`), results presentation, failure diagnosis, parallel execution, project/folder management (`projects`/`folders list|create`, auto-default gate). |
+| `kane-cli testmd` steering | `integrations/kiro-powers/steering/kane-cli-testmd.md` | Full reference for `kane-cli testmd`: file format, frontmatter, `@import`, replay/author cache, `Result.md`, CI patterns, parse errors, generate → testmd pipeline. |
+| `kane-cli generate` steering | `integrations/kiro-powers/steering/kane-cli-generate.md` | Full reference for `kane-cli generate`: the three modes (new / refine / save), clarification round-trips, the refine→save→run loop, typed NDJSON event schema (`generate_*`), result presentation, the generate → testmd handoff. |
 | Hook template | `integrations/kiro-powers/hooks/kane-verify.kiro.hook` | Sample agent hook the user copies to their workspace `.kiro/hooks/`. |
 
 If a fact appears in this integration that is **not** in `SKILL.md` or one of the `references/*.md`, that's a bug — either backfill the canonical source first, or delete the fact from the integration.
 
 ## SKILL.md (+ references) → Kiro Powers mapping
 
-The canonical skill restructured in May 2026 into a thin `SKILL.md` (6 sections, ~260 lines) plus six on-demand `references/*.md`. The Kiro power's two steering files absorb the equivalent depth — Kiro reads the right steering file per workflow, the way Claude Code reads the right reference file on demand.
+The canonical skill is a thin `SKILL.md` (7 sections, ~300 lines) plus on-demand `references/*.md`. The Kiro power's three steering files absorb the equivalent depth — Kiro reads the right steering file per workflow, the way Claude Code reads the right reference file on demand.
 
 | Canonical source | Where it lives in the Kiro power |
 |---|---|
 | `SKILL.md` §1 Live narration & results presentation (Monitor/Bash launch decision is Claude-Code-specific — Kiro keeps its own narration model) | `steering/kane-cli-run.md` → Presenting results |
-| `SKILL.md` §2 Decision tree | `steering/kane-cli-run.md` → Decision tree, and `steering/kane-cli-testmd.md` → Decision tree |
-| `SKILL.md` §3 Building a `run` command — flags, exit codes, examples | `POWER.md` → Command reference (condensed) **and** `steering/kane-cli-run.md` → Full flag reference |
+| `SKILL.md` §2 Decision tree | `steering/kane-cli-run.md` → Decision tree, `steering/kane-cli-testmd.md` → When to recommend `testmd`, and `steering/kane-cli-generate.md` → When to recommend `generate` |
+| `SKILL.md` §3 Building a `run` command — flags, exit codes, examples, bare-objective guardrail | `POWER.md` → Command reference (condensed) **and** `steering/kane-cli-run.md` → Full flag reference |
 | `SKILL.md` §4 Writing objectives — three patterns, "store as", do/don't | `steering/kane-cli-run.md` → Writing objectives — three patterns |
-| `SKILL.md` §5 Parsing `--agent` output — essentials | `steering/kane-cli-run.md` → Parsing the NDJSON output (Event types + Parsing strategy summary) |
-| `SKILL.md` §6 When to read which reference | Kiro analogue: `POWER.md`'s steering-file mapping (POWER.md tells Kiro when to load each steering file) |
+| `SKILL.md` §5 Parsing `--agent` output — essentials (includes `project_folder_auto_defaulted` in typed events) | `steering/kane-cli-run.md` → Parsing the NDJSON output (Event types + Parsing strategy summary) |
+| `SKILL.md` §6 Generate test cases (authoring — no browser) | `POWER.md` → Overview (the third "way Kiro uses it") **and** all of `steering/kane-cli-generate.md` |
+| `SKILL.md` §7 When to read which reference | Kiro analogue: `POWER.md`'s steering-file mapping (POWER.md tells Kiro when to load each steering file) |
 | `references/objectives-cookbook.md` — analyze methods (Visual / Textual-DOM / URL / Title / DevTools→Network/Console/Performance/Cookies/localStorage), operators, chaining, pitfalls, worked examples | `steering/kane-cli-run.md` → Analyze methods — picking the right checkpoint (plus the existing Combining patterns, Assertion specificity, and Do / Don't sections) |
-| `references/testmd.md` — testmd file format, replay & cascade, `@import`, commands, parse errors | All of `steering/kane-cli-testmd.md` |
-| `references/parsing.md` — full NDJSON event schemas (`bifurcation`, `child_agent_*`, `ask_user`, complete `run_end` fields) | `steering/kane-cli-run.md` → Parsing the NDJSON output (full event-type list + Terminal `run_end` event) |
-| `references/debug.md` — log layout, debugging flow, common failure patterns, bug-report heuristic | `steering/kane-cli-run.md` → Failure handling & log inspection + Bug-report heuristic |
+| `references/testmd.md` — testmd file format, replay & cascade, `@import`, commands, parse errors, gate-fires-before-launch note | All of `steering/kane-cli-testmd.md` |
+| `references/generate.md` — generate modes, refine→save→run loop, clarification handling, Functional-only save, generate→testmd handoff | All of `steering/kane-cli-generate.md` |
+| `references/generate-parsing.md` — typed `generate_*` event schema, terminal `generate_done`, exit codes | `steering/kane-cli-generate.md` → Parsing the NDJSON output + Terminal `generate_done` + Exit codes |
+| `references/parsing.md` — full NDJSON event schemas (`project_folder_auto_defaulted`, `bifurcation`, `child_agent_*`, `ask_user`, complete `run_end` fields) | `steering/kane-cli-run.md` → Parsing the NDJSON output (full event-type list + Terminal `run_end` event) |
+| `references/test-manager.md` — project/folder agent surface (`projects`/`folders list|create` NDJSON wire shape, pagination), run-startup auto-default gate, `project_folder_auto_defaulted` event, self-healing for stale IDs | `POWER.md` → Step 3 (project/folder onboarding) **and** `steering/kane-cli-run.md` → Browsing / creating projects and folders + The run-startup auto-default gate **and** `steering/kane-cli-testmd.md` → Quick start (gate note) **and** `steering/kane-cli-generate.md` → Configuration surface (gate note) |
+| `references/debug.md` — log layout, debugging flow, common failure patterns (incl. "did you mean" subcommand and self-healing rows), bug-report heuristic | `steering/kane-cli-run.md` → Failure handling & log inspection + Bug-report heuristic |
 | `references/parallel.md` — when to split, agent prompt template, batch summary | `steering/kane-cli-run.md` → Parallel execution |
 | `references/setup-and-config.md` — install / auth / variables precedence / context files / config commands / Chrome management / directory layout | `POWER.md` → Onboarding (Steps 1–3) + `steering/kane-cli-run.md` → Variables and secrets + Context files + Configuration surface |
 

--- a/integrations/kiro-powers/POWER.md
+++ b/integrations/kiro-powers/POWER.md
@@ -90,16 +90,29 @@ kane-cli config show
 
 If the verification fails, surface the error and re-run login with whatever the user corrects — do not loop on the same bad credentials.
 
-## Step 3 — Pick a project and folder (optional but recommended)
+## Step 3 — Pick a project and folder (optional)
 
-Tests land in a TestMu AI project + folder. Set them once, then forget:
+Tests land in a TestMu AI project + folder. **Setting them is optional** — if nothing is configured, the run-startup gate auto-defaults a project/folder on the first run and announces the choice. Set them explicitly only when the user wants tests filed in a specific place:
 
 ```bash
 kane-cli config project <project-id>       # or the interactive picker in a TTY: kane-cli config project
 kane-cli config folder  <folder-id>        # or:                                 kane-cli config folder
 ```
 
-If Kiro's shell is non-TTY, ask the user for the IDs (or have them run the picker themselves), then set them with the literal ID forms above. Verify with `kane-cli config show`.
+The interactive picker works for **both** OAuth and basic-auth profiles.
+
+If Kiro's shell is non-TTY and the user wants a specific project/folder, browse and create from the command line:
+
+```bash
+kane-cli projects list   [--search <q>] [--limit <n>] [--offset <n>] --agent
+kane-cli projects create "<name>" [--description "<text>"] --agent
+kane-cli folders  list   [--search <q>] [--limit <n>] [--offset <n>] --agent
+kane-cli folders  create "<name>" [--description "<text>"] --agent
+```
+
+NDJSON output: `{id, name}` per row, terminated by `{_meta: "page", limit, offset, returned, has_more}`. Persist the chosen id with `kane-cli config project <id>` / `kane-cli config folder <id>`.
+
+Self-healing: a stale, deleted, revoked, or typo'd project/folder ID is detected on the next run and auto-replaced via the gate — no need to clear it by hand. Verify the current state any time with `kane-cli config show`.
 
 ## Step 4 — (Optional) Install the verify-on-deploy hook
 

--- a/integrations/kiro-powers/POWER.md
+++ b/integrations/kiro-powers/POWER.md
@@ -1,7 +1,7 @@
 ---
 name: "kane-cli"
-displayName: "Kane CLI — Browser Automation"
-description: "Drive a real browser from natural-language objectives. Kane CLI manages Chrome, an AI agent, and a TestMu AI session, then emits structured NDJSON Kiro can parse. Use for any task that needs a real browser: navigation, form fills, search, UI checks, screenshots, deploy verification. Includes a Markdown test framework (`kane-cli testmd`) for committable, replay-cached browser tests."
+displayName: "Kane CLI — Browser Automation & AI Test Authoring"
+description: "Drive a real browser from natural-language objectives, AND author structured test cases / scenarios from a feature description. Kane CLI manages Chrome, an AI agent, and a TestMu AI session, then emits structured NDJSON Kiro can parse. Use for any task that needs a real browser (navigation, form fills, search, UI checks, screenshots, deploy verification), to author test cases / scenarios from a requirement (`kane-cli generate`), or for committable, replay-cached browser tests (`kane-cli testmd`)."
 keywords:
   - "kane-cli"
   - "kaneai"
@@ -16,6 +16,11 @@ keywords:
   - "verify-deploy"
   - "smoke-test"
   - "testmd"
+  - "test-case-generation"
+  - "test-scenarios"
+  - "test-authoring"
+  - "ai-test-generation"
+  - "qa"
 author: "TestMu AI"
 ---
 
@@ -120,14 +125,15 @@ A sample hook file ships in this power at `hooks/kane-verify.kiro.hook`. Copy it
 
 # Overview
 
-`kane-cli` is a CLI for driving Chrome from natural-language objectives. Each run is a single shot: Kane CLI launches (or attaches to) Chrome, asks an agent to perform the objective, emits one NDJSON event per agent step on stdout, and terminates with a single `run_end` event when the objective is finished.
+`kane-cli` is a CLI with two surfaces: driving Chrome from natural-language objectives, **and** authoring structured test cases from a plain-language description. Browser invocations are single-shot — Kane CLI launches (or attaches to) Chrome, asks an agent to perform the objective, emits one NDJSON event per agent step on stdout, and terminates with a single `run_end` event. Generation invocations are also single-shot — one turn, then exit, with continuity carried by a request id.
 
-Two ways Kiro uses it:
+Three ways Kiro uses it:
 
 1. **Ad-hoc browser tasks — `kane-cli run`.** One-shot natural-language objectives. The process exits when the agent reports `run_end`. Use this for navigation, form fills, search, verification, screenshots, data extraction, and deploy smoke tests.
 2. **Committable, replayable tests — `kane-cli testmd`.** Tests live as `_test.md` files in the repo. The first run authors each step (agent figures the page out); every later run replays from a cache — no agent, no LLM cost, much faster. Use this for regression suites, CI gates, and validation hooks.
+3. **AI test-case authoring — `kane-cli generate`.** Turns a plain-language description of *what to test* into structured Test Scenarios + typed Test Cases (Positive / Negative / Edge). **No browser is launched.** Reach for it whenever a task needs test cases written — don't hand-draft them in chat or a scratch file. `--save` writes Functional cases as runnable `_test.md`, which feeds straight into `kane-cli testmd run` (the generate → testmd pipeline).
 
-**Always invoke with `--agent`.** It makes Kane CLI emit structured NDJSON to stdout (progress events, then a terminal `run_end` event) that Kiro can parse. Without `--agent` you get a TUI Kiro can't read.
+**Always invoke with `--agent`.** It makes Kane CLI emit structured NDJSON to stdout (progress events, then a terminal `run_end` / `generate_done` event) that Kiro can parse. Without `--agent` you get a TUI Kiro can't read.
 
 Other capabilities to know about:
 
@@ -143,10 +149,11 @@ Kane CLI requires a TestMu AI account. Configuration is per-flag — do not rely
 
 When the user's task makes one of these patterns relevant, load the matching steering file before composing the command:
 
-- **`steering/kane-cli-run.md`** — every `kane-cli run` invocation. Covers objective patterns (action / assertion / extraction), the full flag reference, NDJSON parsing, results presentation, failure diagnosis, and parallel execution.
+- **`steering/kane-cli-run.md`** — every `kane-cli run` invocation. Covers objective patterns (action / assertion / extraction), the full flag reference, NDJSON parsing, results presentation, failure diagnosis, parallel execution, and project/folder management.
 - **`steering/kane-cli-testmd.md`** — any time the user wants a committable test, or is reading / editing / running a `_test.md` file. Covers the `kane-cli testmd` commands, `_test.md` file format and frontmatter, `@import` composition, the replay-vs-author cache model, `Result.md`, lock conflicts, and CI patterns.
+- **`steering/kane-cli-generate.md`** — any time the user wants test cases or scenarios **written** (no browser action). Covers the three generate modes (new / refine / save), clarification round-trips, the refine→save→run loop, the typed NDJSON event schema, and the generate → testmd handoff.
 
-Default to `kane-cli-run.md` for one-shot browser tasks. Switch to `kane-cli-testmd.md` the moment the user says anything like "save this test", "commit this", "regression / smoke test", "make this replayable", or "run in CI" — or asks about a `_test.md` file by name.
+Default to `kane-cli-run.md` for one-shot browser tasks. Switch to `kane-cli-testmd.md` the moment the user says anything like "save this test", "commit this", "regression / smoke test", "make this replayable", or "run in CI" — or asks about a `_test.md` file by name. Switch to `kane-cli-generate.md` when the user says anything like "write test cases for", "give me a test suite for", "generate tests for", "what edge cases should we cover" — or when the task needs cases authored but no browser. **Don't hand-draft test cases in chat or a scratch file** — load the generate steering and use `kane-cli generate`.
 
 # Command reference (condensed)
 

--- a/integrations/kiro-powers/steering/kane-cli-generate.md
+++ b/integrations/kiro-powers/steering/kane-cli-generate.md
@@ -1,0 +1,288 @@
+# Kane CLI — `kane-cli generate` steering
+
+Load this steering file whenever the user wants **test cases or test scenarios written** — because they asked, or because the task needs them — rather than a browser action. `kane-cli generate` turns a plain-language description of *what to test* into structured Test Scenarios (logical groupings), each containing typed Test Cases (Positive / Negative / Edge). It does **not** drive a browser. The result is a tree of scenarios + cases you present to the user, refine conversationally, and optionally save as runnable `_test.md` files.
+
+The single rule governing this framework: **every invocation is one turn, then exit.** There is no interactive session — continuity across turns is carried by a request id that the previous turn hands back. Treat each `kane-cli generate` call as one round-trip with the AI Test Case Generator.
+
+`kane-cli run` is for browser actions. `kane-cli testmd` is for running saved tests. `kane-cli generate` is for **authoring** test cases — when a task says "write tests for X" or "I need a regression suite for the checkout flow", reach for this, not for hand-drafting cases in chat or a scratch file.
+
+---
+
+# When to recommend `generate`
+
+The decision is about the **deliverable**: does the user want browser action, a saved test to run, or a *suite of test cases to write*?
+
+## User-phrase triggers
+
+| User says | Use |
+|---|---|
+| "write test cases for the login flow" | ✅ `generate` |
+| "give me a test suite for checkout" | ✅ `generate` |
+| "what edge cases should we cover for the password reset?" | ✅ `generate` |
+| "generate tests for the new feature spec" | ✅ `generate` |
+| "more negative cases for this scenario" | ✅ `generate` with `--refine` |
+| "save these as runnable tests" | ✅ `generate` with `--save`, then `kane-cli testmd run` |
+| "run a smoke test on the checkout page" | ❌ `kane-cli run` |
+| "verify the dashboard loads after login" | ❌ `kane-cli run` |
+| "save THIS browser session as a regression test" | ❌ `kane-cli run --name`, then `kane-cli testmd` |
+
+## When the intent is unclear
+
+Ask, don't guess:
+
+> "Do you want me to write test cases for this (no browser), or run a browser check?"
+
+Default to `kane-cli generate` when the task needs cases authored. **Don't hand-draft test cases in chat or a scratch file** — generate them so they come out structured, refinable, and runnable as `_test.md`.
+
+---
+
+# The three modes — one turn per invocation, then exit
+
+There is **no interactive session**. Each invocation runs exactly one generation turn and exits. Continuity across turns is carried by a **request id** (`--req <id>`) that the previous turn's terminal line hands back.
+
+| Mode | Command | Notes |
+|---|---|---|
+| **New** | `kane-cli generate "<what to test>" --agent` | Starts a fresh request. Capture the request id from the terminal line. |
+| **Refine** | `kane-cli generate "<change>" --refine --req <id> --agent` | Adjusts an existing request. `--refine` **and** `--req` required; needs a change description. |
+| **Save** | `kane-cli generate --save --req <id> [--out <dir>] --agent` | Writes the request's Functional cases to `_test.md`. No new turn, takes no objective. |
+
+`--refine` and `--save` always run headless (even from a terminal).
+
+## Flag reference
+
+| Flag | Purpose |
+|---|---|
+| `--agent` | **Required for Kiro.** Typed NDJSON on stdout. Auto-on when stdin is not a TTY, but pass it explicitly. |
+| `--req <id>` | The request id to `--refine` or `--save`. |
+| `--out <dir>` | Save target — **only** with `--save`; default `<cwd>/.testmuai/tests`. |
+| `--name <name>` | Names the run and the saved suite folder. |
+| `--scenario-limit <n>` / `--per-scenario-limit <n>` | Cap scenarios / cases-per-scenario. |
+| `--memory` | Use the memory layer — reuse relevant existing cases, reduce duplicates. |
+| `--project <id>` / `--folder <id>` | Test Manager project / folder. |
+| `--env prod\|stage` · `--username` / `--access-key` | Environment / auth (same as `run`). |
+
+If neither `--project`/`--folder` nor a saved project/folder is set when generation starts, Kane CLI auto-resolves one headlessly and emits a `project_folder_auto_defaulted` event before `generate_start` — surface as a one-line note and continue parsing.
+
+---
+
+# The refine → save → run loop
+
+```bash
+# 1. New request
+kane-cli generate "checkout flow on a shopping site" --agent
+#    → terminal line carries request id (e.g. 23271) + Refine/Save hints
+
+# 2. Refine (repeat as needed)
+kane-cli generate "also cover an expired card and an out-of-stock item" --refine --req 23271 --agent
+
+# 3. Save the Functional cases as runnable _test.md
+kane-cli generate --save --req 23271 --agent
+#    → <cwd>/.testmuai/tests/<suite>/<scenario>/<case>_test.md
+
+# 4. Run / replay them — switches to the `kane-cli-testmd` steering file
+kane-cli testmd run .testmuai/tests/<suite>/<scenario>/<case>_test.md --agent
+```
+
+**Save is Functional-only.** `--save` writes only test cases whose category is **Functional** — those are the ones runnable as `_test.md`. Non-functional cases (Security, Performance, etc.) are generated and shown in the result but are **not** written; saving a request with no Functional cases writes nothing and says so. Saved files are ordinary `_test.md` tests — see the **`kane-cli-testmd`** steering file for running, editing, and replay. This is the **generate → testmd** pipeline: author cases here, run them there.
+
+---
+
+# Clarifications — act on them, never drop them
+
+If a turn ends with a **clarification question**, that is **success (exit 0)**, not an error — the generator needs an answer before it can continue. You must act on it:
+
+1. Read the question.
+2. **Decide** — answer it yourself from context, **or** surface it to your user and get an answer.
+3. **Re-invoke** with the answer as a refine:
+
+   ```bash
+   kane-cli generate "<your answer>" --refine --req <id> --agent
+   ```
+
+Never drop a clarification. A turn that ended awaiting one is not "done" — it's blocked on a single round-trip.
+
+---
+
+# Parsing the NDJSON output
+
+> **Internal reference only.** Never echo these field names (`generate_snapshot`, `request_id`, `generate_done`, `generate_clarification`, `_meta`) back to the user. Translate them into plain language.
+
+Unlike `run` (which has untyped `step`/`status` progress lines), **every `generate` line is typed** — it always has a `type` field. That makes parsing simpler:
+
+```
+for each line on stdout:
+  parse JSON, switch on obj.type
+  if obj.type === "generate_done"          → terminal event, stop parsing
+  if obj.type === "generate_snapshot"      → the deliverable (full scenarios + cases)
+  if obj.type === "generate_clarification" → turn ended awaiting an answer (still exit 0)
+  else                                     → progress / informational
+```
+
+Build post-turn logic on **`generate_done`** (terminal, stable schema) and read the result from **`generate_snapshot`** (emitted once, at turn end).
+
+## Event types
+
+Generate-specific (typed `generate_*`):
+
+| `type` | Key fields | Meaning → what to do |
+|---|---|---|
+| `generate_start` | `request_id`, `objective_chars`, `scenario_limit`, `per_scenario_limit`, `is_refine` | Turn began. **Capture `request_id`** — it's the handle for every later `--refine` / `--save`. `is_refine` distinguishes a new request from a continuation. |
+| `generate_thinking` | `took_ms` | Liveness only. Narrate "thinking…" or ignore. |
+| `generate_progress` | `pct` | Milestone (25 / 50 / 75 / 100). Optional progress display — not a completion signal. |
+| `generate_snapshot` | `scenario_count`, `case_count`, `scenarios[]` | **The deliverable** — full scenarios, each with its cases. Each case carries `title`, `polarity` (`"p"`/`"n"`/`"e"` = Positive / Negative / Edge), `category` (`"Functional"`, `"Security"`, …), `priority`. Emitted exactly once. Present per "Presenting results" below. |
+| `generate_clarification` | `text` | The generator needs an answer; the turn ended (exit 0) awaiting it. **Not an error** — answer via `--refine --req`. |
+| `generate_chat` | `text` | The model's prose reply (e.g. what a refine changed). Show as info. |
+| `generate_save_result` | `suite_dir`, `saved`, `fell_back`, `warning?` | `--save` wrote files. `saved` = files written; `fell_back` = cases written as prose because they couldn't be expanded; `warning` e.g. `"no functional test cases"`. |
+| `generate_done` | `request_id`, `status`, `scenario_count`, `case_count`, `refine_hint`, `save_hint`, `suite_dir?` | **Terminal line.** Branch on `status`; use `refine_hint` / `save_hint` **verbatim** as the next command. `suite_dir` present only after a `--save`. |
+
+Shared with `run` (not generate-specific):
+
+| `type` | Fields | Meaning |
+|---|---|---|
+| `project_folder_auto_defaulted` | resolved project + folder (id, name) | Run-startup gate auto-resolved a project/folder when none was configured. Fires **before** `generate_start`. Translate to a one-line note ("Kane CLI auto-selected project X / folder Y for this turn"). |
+| `error` | `message` | A failure occurred; pair with the exit code to decide retry vs abort. |
+| `update_available` | `current`, `latest`, `severity` | A newer Kane CLI exists. Informational; emitted before `generate_start`. |
+
+## Terminal `generate_done`
+
+Example after a **`--save`** run (note `suite_dir` — a new/refine turn omits it):
+
+```json
+{
+  "type": "generate_done",
+  "request_id": "23271",
+  "status": "completed",
+  "scenario_count": 3,
+  "case_count": 11,
+  "refine_hint": "kane-cli generate \"<refinement>\" --refine --req 23271",
+  "save_hint": "kane-cli generate --save --req 23271",
+  "suite_dir": ".testmuai/tests/checkout-23271"
+}
+```
+
+`status` values:
+
+| Value | Exit | Meaning |
+|---|---|---|
+| `completed` | `0` | Turn finished cleanly (includes turns that ended with a clarification). |
+| `failed` / `ended` | `1` | Generation failed or stopped without producing the deliverable. |
+| `stopped` | `3` | Stopped / cancelled. |
+
+The hints carry no `--agent` flag, but it is auto-on for non-TTY callers (agents/pipes), so re-invoking a hint verbatim still yields NDJSON.
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Turn completed (including a turn that ended with a clarification). |
+| `1` | Generation failed or stopped without producing the deliverable. |
+| `2` | Error (auth / setup / transport, or an invalid flag combination). |
+| `3` | Stopped / cancelled. |
+| `130` | Interrupted (Ctrl-C). |
+
+Invalid flag combinations exit `2` with a message on stderr. The full set:
+
+- `--refine` and `--save` together
+- `--refine` without `--req`
+- `--refine` without a change description
+- `--refine` combined with `--out` (`--out` is save-only)
+- `--save` without `--req`
+- `--save` with a description (it takes none)
+- `--out` without `--save`
+- `--req` without `--refine` or `--save`
+- a new generation with no description
+
+---
+
+# Presenting results
+
+Present the result **adaptively** based on size, and always offer the next-step commands the terminal line hands back.
+
+## ≤ ~30 cases → a nested tree
+
+Scenario, then each case with its type tag:
+
+```
+✓ Generated 3 scenarios · 11 cases  (request 23271)
+
+▸ Login
+   - Valid credentials [Positive]
+   - Wrong password [Negative]
+   - Empty fields [Edge]
+▸ Checkout
+   - Guest checkout [Positive]
+   - Expired card [Negative]
+   - Cart total mismatch [Edge]
+▸ Cart management
+   ...
+```
+
+## More than ~30 cases → summary + scenario list
+
+Cases on request:
+
+```
+✓ Generated 6 scenarios · 84 cases  (request 23271)
+
+  • Login (12 cases)
+  • Checkout (20 cases)
+  • Cart management (14 cases)
+  • ...
+```
+
+Expand a scenario's cases only when the user asks.
+
+## Always end with next-step hints
+
+The terminal `generate_done` event carries `refine_hint` and `save_hint` — present them **verbatim** (they already carry the request id). Don't hand-build them.
+
+> Want to refine? `kane-cli generate "<refinement>" --refine --req 23271`
+> Ready to save the Functional cases? `kane-cli generate --save --req 23271`
+
+## Field names are internal
+
+Never expose `generate_snapshot`, `request_id`, `generate_done`, `polarity`, `category`, `_meta` to the user. Translate `"p"` → "Positive", `"n"` → "Negative", `"e"` → "Edge". Translate scenarios as "scenarios" and cases as "test cases" — that's the user-facing vocabulary.
+
+---
+
+# Failure handling
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Exit `2` with "invalid flag combination" | Mixed `--refine` + `--save`, or missing `--req` | Re-invoke with the correct mode (see "The three modes" above). |
+| Exit `2` with "auth/setup" | Credentials missing or environment unset | `kane-cli whoami`; re-run `kane-cli login` if needed. |
+| Turn ended with `generate_clarification` | Generator needs an answer — **this is exit 0, not a failure** | Read the question, decide on an answer (yourself or via the user), re-invoke `kane-cli generate "<answer>" --refine --req <id> --agent`. |
+| `generate_save_result` with `warning: "no functional test cases"` | The request has no Functional cases to save | Either refine to add Functional cases, or accept that the suite is non-functional (Security / Performance / etc.) and won't produce `_test.md` files. |
+| Bare-objective shortcut: `kane-cli "<description>"` exits `2` with "did you mean" | The `generate` subcommand is mandatory | Re-invoke as `kane-cli generate "<description>" --agent`. Same rule for `run` / `testmd run`. |
+
+---
+
+# Configuration surface (reference)
+
+Generate uses the same auth and project/folder configuration as `run` and `testmd`:
+
+```bash
+kane-cli whoami
+kane-cli config show
+kane-cli config project <project-id>      # or the interactive picker in TTY (OAuth + basic both work)
+kane-cli config folder  <folder-id>       # or the interactive picker in TTY
+kane-cli projects list   [--search <q>] [--limit <n>] [--offset <n>] --agent
+kane-cli projects create "<name>" [--description "<text>"] --agent
+kane-cli folders  list   [--search <q>] [--limit <n>] [--offset <n>] --agent
+kane-cli folders  create "<name>" [--description "<text>"] --agent
+```
+
+If nothing is configured, the run-startup gate auto-defaults a project/folder before `generate_start` and emits `project_folder_auto_defaulted`. Pre-configure only when the user wants generated cases filed in a specific place. See the **`kane-cli-run`** steering file for full project/folder mechanics.
+
+---
+
+# Handoff to `kane-cli-testmd`
+
+Once `--save` has written `_test.md` files, every later interaction with those files is a `kane-cli testmd` workflow:
+
+- Run them: `kane-cli testmd run <path> --agent`
+- List them: `kane-cli testmd list`
+- Inspect: `kane-cli testmd status <path>`
+- Re-export code: `kane-cli testmd export <path> --code-language python|javascript`
+
+**Switch to the `kane-cli-testmd` steering file** once the user moves from authoring to running. Generate's job ends at `--save`; testmd's job picks up from there.

--- a/integrations/kiro-powers/steering/kane-cli-run.md
+++ b/integrations/kiro-powers/steering/kane-cli-run.md
@@ -21,10 +21,11 @@ When a dependency check fails, run the fix yourself. Only ask the user when the 
 - Yes → continue.
 
 **What does the user want?**
-- One browser task → build a single `kane-cli run "<objective>" --agent …` command.
+- One browser task → build a single `kane-cli run "<objective>" --agent …` command. **The `run` subcommand is mandatory** — `kane-cli "<objective>"` exits `2` with a "did you mean" hint.
 - Test / verify something → same, with assertion phrasing.
 - Extract data from a page → same, using the `store … as '<name>'` pattern.
 - Save / re-run / commit a test → switch to `kane-cli testmd`. Load the **`kane-cli-testmd`** steering file.
+- Browse / create a Test Manager project or folder, or interpret a `project_folder_auto_defaulted` event → use `kane-cli projects list|create` / `kane-cli folders list|create` (NDJSON under `--agent`). The run-startup gate auto-defaults a project/folder when nothing is configured and emits `project_folder_auto_defaulted` before the first progress event.
 - Multiple independent flows → decompose into N self-contained sub-objectives and run them in parallel.
 - Debug a failed run → inspect logs at `run_dir/run-test/actions.ndjson` and the failing-step screenshot.
 
@@ -240,13 +241,14 @@ Override either per-run with `--global-context` / `--local-context`.
 
 | `type` | Key fields | Purpose |
 |---|---|---|
+| `project_folder_auto_defaulted` | resolved project + folder (id, name) | Run-startup gate auto-resolved a project/folder when none was configured (or the cached one was stale/invalid). Fires **before** any progress event. Translate to a one-line note ("kane-cli auto-selected project X / folder Y for this run") and continue parsing. |
 | `bifurcation`       | `flows[]`, `count`                          | Agent split the objective into sub-flows |
 | `child_agent_start` | `child_id`, `objective`, `parent_step`      | Child agent spawned |
 | `child_agent_end`   | `child_id`, `success`, `steps_taken`, `summary` | Child agent finished |
 | `ask_user`          | `question`, `step_index`, `options?`        | Agent needs input (auto-disabled when stdin is non-TTY) |
 | `error`             | `message`                                   | Error |
 
-There is no `run_start` event — the first line is either a `bifurcation` or a progress object.
+There is no `run_start` event — the first line is either `project_folder_auto_defaulted`, a `bifurcation`, or a progress object.
 
 `ask_user` is auto-disabled when stdin is not a TTY. Since Kiro runs Kane CLI as a subprocess, `ask_user` events will not be emitted — write objectives that don't require interactive input.
 
@@ -414,7 +416,9 @@ The `run_end` event tells you `session_dir` and `run_dir`. Use those paths direc
 | 🔄 Agent repeats the same action | Stuck in a loop / page didn't change | Rephrase the objective, add an explicit wait or assertion |
 | 🎯 Agent clicks the wrong element | Ambiguous UI, multiple similar elements | Be more specific ("click the **blue** Submit button in the **checkout form**") |
 | 👁️ Agent says "done" but nothing happened | Objective too vague | Add a concrete assertion ("assert the confirmation page shows an order number") |
-| 💀 Exit `2`, no steps | Auth or Chrome failure | Check `kane-cli whoami`; ensure Chrome is installed |
+| 💀 Exit `2`, no steps | Auth, TMS credential exchange, or Chrome failure | Check `kane-cli whoami`; ensure Chrome is installed |
+| ❓ Exit `2` with "did you mean …" | Missing `run` subcommand — agent invoked `kane-cli "<objective>"` instead of `kane-cli run "<objective>"` | Re-invoke with `run` (same rule for `testmd run` / `generate`) |
+| 📤 Upload silently fails after setting a project/folder by hand | Saved ID is invalid (typo, deleted, no access) | No action needed — the next run detects the 4xx and auto-defaults a working project/folder. To rebind: `kane-cli config project` or `kane-cli projects list` → `kane-cli config project <id>` |
 | ⏱️ Exit `3` | Timeout or cancelled | Raise `--timeout`, raise `--max-steps`, or split the objective |
 | 🚫 `CDP endpoint not reachable` | Chrome not running | Drop `--cdp-endpoint` and let Kane CLI auto-launch Chrome |
 
@@ -495,9 +499,32 @@ kane-cli whoami
 kane-cli config show
 kane-cli config set-window 1920x1080
 kane-cli config chrome-profile <path>     # or the interactive picker in TTY
-kane-cli config project <project-id>      # or the interactive picker in TTY
+kane-cli config project <project-id>      # or the interactive picker in TTY (OAuth + basic both work)
 kane-cli config folder  <folder-id>       # or the interactive picker in TTY
 kane-cli feedback --test-id <id> --feedback-type <positive|negative> --details "..."
 ```
+
+## Browsing / creating projects and folders (non-TTY)
+
+When Kiro's shell is non-TTY, the picker is not appropriate. Use the agent surface:
+
+```bash
+kane-cli projects list   [--search <q>] [--limit <n>] [--offset <n>] --agent
+kane-cli projects create "<name>" [--description "<text>"] --agent
+kane-cli folders  list   [--search <q>] [--limit <n>] [--offset <n>] --agent
+kane-cli folders  create "<name>" [--description "<text>"] --agent
+```
+
+NDJSON wire shape — each result row is `{id, name}`, terminated by `{_meta: "page", limit, offset, returned, has_more}` (no `total` — paginate while `has_more === true`). `folders` operate inside the currently configured project.
+
+## The run-startup auto-default gate
+
+Every `run`, `testmd run`, and `generate` validates the cached project/folder before launching. Three outcomes:
+
+1. Cached project/folder still valid → run proceeds, no event.
+2. Nothing configured **or** cached IDs are gone / invalid / inaccessible → Kane CLI auto-resolves (find-or-create) and emits `project_folder_auto_defaulted` on stdout before any progress event. Surface as a one-liner ("Kane CLI auto-selected project X / folder Y for this run").
+3. No usable credentials in a non-TTY context → exit `2` (auth/setup).
+
+Self-healing: stale, deleted, revoked, or typo'd project IDs trigger 4xx from TMS and the gate re-resolves automatically — no need to clear them by hand.
 
 Project-local overrides live in `./.testmuai/` (`context.md`, `variables/*.json`). Global config and history live in `~/.testmuai/kaneai/`. Pass everything through flags — do **not** rely on environment variables for Kane CLI configuration.

--- a/integrations/kiro-powers/steering/kane-cli-run.md
+++ b/integrations/kiro-powers/steering/kane-cli-run.md
@@ -25,6 +25,7 @@ When a dependency check fails, run the fix yourself. Only ask the user when the 
 - Test / verify something → same, with assertion phrasing.
 - Extract data from a page → same, using the `store … as '<name>'` pattern.
 - Save / re-run / commit a test → switch to `kane-cli testmd`. Load the **`kane-cli-testmd`** steering file.
+- **Test cases or scenarios written** — because the user asked, or because the task needs them (no browser action) → **don't hand-draft them**; load the **`kane-cli-generate`** steering file and use `kane-cli generate`. Trigger phrases: "write tests for", "test cases for", "test suite for", "what edge cases", "generate tests for".
 - Browse / create a Test Manager project or folder, or interpret a `project_folder_auto_defaulted` event → use `kane-cli projects list|create` / `kane-cli folders list|create` (NDJSON under `--agent`). The run-startup gate auto-defaults a project/folder when nothing is configured and emits `project_folder_auto_defaulted` before the first progress event.
 - Multiple independent flows → decompose into N self-contained sub-objectives and run them in parallel.
 - Debug a failed run → inspect logs at `run_dir/run-test/actions.ndjson` and the failing-step screenshot.

--- a/integrations/kiro-powers/steering/kane-cli-testmd.md
+++ b/integrations/kiro-powers/steering/kane-cli-testmd.md
@@ -206,6 +206,28 @@ On exit, Kane CLI writes the session to `<cwd>/.testmuai/tests/amazon-search_tes
 
 Slug rules: `[a-zA-Z0-9_-]+`. Pick a slug that reads as a filename — e.g. `login-smoke`, `checkout-happy-path`, `dashboard-regression`.
 
+## Authoring `_test.md` from a description — the generate → testmd pipeline
+
+When the user wants test cases written from scratch — from a feature spec, a requirement, or just a description of what to test — **don't hand-draft them and don't capture them via a live `--name` session.** Use `kane-cli generate` to author structured Functional cases first, save them as runnable `_test.md`, then run them here:
+
+```bash
+# 1. Author scenarios + cases from a description
+kane-cli generate "checkout flow on a shopping site" --agent
+#    → capture the request id (e.g. 23271)
+
+# 2. Refine if needed (repeat as often as needed)
+kane-cli generate "also cover an expired card and an out-of-stock item" --refine --req 23271 --agent
+
+# 3. Save the Functional cases as runnable _test.md files
+kane-cli generate --save --req 23271 --agent
+#    → <cwd>/.testmuai/tests/<suite>/<scenario>/<case>_test.md
+
+# 4. Run them — back in testmd territory
+kane-cli testmd run .testmuai/tests/<suite>/<scenario>/<case>_test.md --agent
+```
+
+Full mechanics (the three modes, clarification round-trips, presenting scenarios + cases, the typed event schema) live in the **`kane-cli-generate`** steering file. Load that file the moment the user asks for cases to be written; come back here to run them.
+
 ---
 
 # Composition with `@import`

--- a/integrations/kiro-powers/steering/kane-cli-testmd.md
+++ b/integrations/kiro-powers/steering/kane-cli-testmd.md
@@ -65,6 +65,8 @@ kane-cli testmd run amazon_test.md --agent
 
 The first run authors every step (the agent figures the page out). The second run replays each step from `output-amazon/.internal/` in seconds. Commit both the `_test.md` and the `output-amazon/` directory.
 
+Before the test launches, `kane-cli testmd run` validates the cached Test Manager project/folder. If none is configured (or the cached value is stale/invalid), the run-startup gate auto-defaults a project/folder and emits a `project_folder_auto_defaulted` event on stdout — surface it as a one-line note ("Kane CLI auto-selected project X / folder Y for this test") and continue parsing. Browse / create explicitly with `kane-cli projects list|create` and `kane-cli folders list|create` (see the `kane-cli-run` steering file).
+
 ---
 
 # Command reference

--- a/skill-installer/skills/SKILL.md
+++ b/skill-installer/skills/SKILL.md
@@ -138,6 +138,7 @@ When the user's request involves a browser — or writing test cases:
 - Multiple independent browser tasks → Read `references/parallel.md` first
 - Debug a failed run → Read `references/debug.md`
 - Configure kane-cli or check directory layout → Read `references/setup-and-config.md`
+- Browse / create / pick a Test Manager project or folder, or interpret the auto-default event → Read `references/test-manager.md`
 - You need the full NDJSON event schema (rare — §5's summary covers 90% of cases) → Read `references/parsing.md`
 
 **Every run, always:** follow §1 above.
@@ -300,4 +301,5 @@ Internal event/field names (`generate_snapshot`, `request_id`, …) are for pars
 | Multiple independent browser tasks | `references/parallel.md` |
 | Need full NDJSON event schema (`run`) | `references/parsing.md` |
 | Need the `generate` NDJSON event schema | `references/generate-parsing.md` |
+| Browse / create projects or folders, or parse the auto-default event | `references/test-manager.md` |
 | First-time install, auth, or full config | `references/setup-and-config.md` |

--- a/skill-installer/skills/SKILL.md
+++ b/skill-installer/skills/SKILL.md
@@ -55,7 +55,7 @@ Progress events have `step`/`status`/`remark` fields and **no `type` field**.
 #### What to skip
 
 - Individual passing steps — fold them into the overall progress line
-- Internal field names (`step`, `status`, `remark`, `run_end`, `final_state`, `bifurcation`, `session_dir`, etc.) — translate to plain language
+- Internal field names (`step`, `status`, `remark`, `run_end`, `final_state`, `bifurcation`, `session_dir`, `project_folder_auto_defaulted`, etc.) — translate to plain language. A `project_folder_auto_defaulted` event fires before progress when the run-startup gate auto-resolves a project/folder; surface it as one line ("kane-cli auto-selected project X / folder Y for this run") and move on. Details: `references/test-manager.md`.
 
 #### Example output for a 15-step run with one failure
 
@@ -151,6 +151,8 @@ When the user's request involves a browser — or writing test cases:
 kane-cli run "<objective>" --agent [options]
 ```
 
+> The `run` subcommand is **mandatory**. `kane-cli "<objective>"` (no `run`) does **not** work — unknown first tokens exit `2` with a "did you mean" suggestion. Same rule applies to `kane-cli testmd run …` and `kane-cli generate …`.
+
 `--agent` is mandatory — it switches stdout to NDJSON. Most-used flags:
 
 | Flag | Purpose | Default |
@@ -234,7 +236,7 @@ Action → extraction → assertion in one objective:
 Stdout is NDJSON, one event per line. There are two shapes:
 
 - **Progress events** (most events) have `step` (1-based), `status` (`passed`/`failed`), `remark` — and **no `type` field**.
-- **Typed events** have a `type` field: `bifurcation`, `child_agent_start`, `child_agent_end`, `ask_user`, `error`, and finally `run_end`.
+- **Typed events** have a `type` field: `project_folder_auto_defaulted` (run-startup gate, fires before any progress when no project/folder is configured), `bifurcation`, `child_agent_start`, `child_agent_end`, `ask_user`, `error`, and finally `run_end`.
 
 Parsing strategy:
 

--- a/skill-installer/skills/references/debug.md
+++ b/skill-installer/skills/references/debug.md
@@ -30,7 +30,9 @@ The `run_end` event provides `session_dir` and `run_dir` paths. Use those direct
 | 🔄 Agent repeats same action | Stuck in a loop / page didn't change | Rephrase objective, add explicit wait or assertion |
 | 🎯 Agent clicks wrong element | Ambiguous UI, multiple similar elements | Be more specific: "click the **blue** 'Submit' button in the **checkout form**" |
 | 👁️ Agent says done but didn't finish | Objective too vague | Add explicit assertions: "assert the confirmation page shows order number" |
-| 💀 Exit code 2, no steps | Auth or Chrome failure | Check `kane-cli whoami`, verify Chrome is available |
+| 💀 Exit code 2, no steps | Auth, TMS credential exchange, or Chrome failure | Check `kane-cli whoami`, verify Chrome is available |
+| ❓ Exit code 2 with "did you mean …" | Bare-objective shortcut — agent ran `kane-cli "<objective>"` without the `run` subcommand | Re-invoke as `kane-cli run "<objective>" --agent` (same rule for `testmd run` / `generate`) |
+| 📤 Upload silently fails after configuring a project/folder by hand | Saved ID is invalid (typo, deleted, no access) | No action needed — the next run detects the 4xx and auto-defaults a working project/folder. To rebind manually: `kane-cli config project` (TTY picker) or `kane-cli projects list` → `kane-cli config project <id>` (see `references/test-manager.md`) |
 | ⏱️ Exit code 3 | Timeout or cancelled | Increase `--timeout` or `--max-steps`, or split into smaller objectives |
 | 🚫 "CDP endpoint not reachable" | Chrome not running | Let kane-cli manage Chrome (remove `--cdp-endpoint`) |
 

--- a/skill-installer/skills/references/generate-parsing.md
+++ b/skill-installer/skills/references/generate-parsing.md
@@ -36,6 +36,7 @@ Shared with `run` (NOT generate-specific — don't treat as part of the generate
 
 | `type` | Fields | Meaning |
 |---|---|---|
+| `project_folder_auto_defaulted` | resolved project + folder (id, name) | Run-startup gate auto-resolved a project/folder when none was configured (or the cached one was stale/invalid). Fires before `generate_start`. Translate to plain language (see `references/test-manager.md`). |
 | `error` | `message` | A failure occurred; pair with the exit code to decide retry vs abort. |
 | `update_available` | `current`, `latest`, `severity` | A newer kane-cli exists. Informational; emitted before `generate_start`. |
 

--- a/skill-installer/skills/references/generate.md
+++ b/skill-installer/skills/references/generate.md
@@ -33,6 +33,8 @@ There is **no interactive session**. Each invocation runs exactly one generation
 | `--project <id>` / `--folder <id>` | Test Manager project / folder |
 | `--env prod\|stage` · `--username` / `--access-key` | Environment / auth (same as `run`) |
 
+If neither `--project`/`--folder` nor a saved project/folder is set when generation starts, kane-cli auto-resolves one headlessly and emits a `project_folder_auto_defaulted` event before `generate_start`. Translate it to a one-line note for the user — full handling lives in `references/test-manager.md`.
+
 ## Presenting a result (adaptive)
 
 The terminal data carries the full scenarios + cases. **Present it based on size**:

--- a/skill-installer/skills/references/parsing.md
+++ b/skill-installer/skills/references/parsing.md
@@ -28,6 +28,7 @@ These are **untyped** — they have no `type` field. Do **not** key on `event.ty
 
 | Event (`type` field) | Key Fields | Purpose |
 |-------|-----------|---------|
+| `project_folder_auto_defaulted` | resolved project + folder (id, name) | Run-startup gate auto-resolved a project/folder when none was configured (or the cached one was stale/invalid). Fires before any progress event on `run` / `testmd run` / `generate`. Translate to plain language (see `references/test-manager.md`). |
 | `bifurcation` | `flows[]`, `count` | Agent split objective into sub-flows |
 | `child_agent_start` | `child_id`, `objective`, `parent_step` | Child agent spawned |
 | `child_agent_end` | `child_id`, `success`, `steps_taken`, `summary` | Child agent finished |

--- a/skill-installer/skills/references/setup-and-config.md
+++ b/skill-installer/skills/references/setup-and-config.md
@@ -93,6 +93,8 @@ kane-cli config project <project-id>          # TMS project ID (or interactive p
 kane-cli config folder <folder-id>            # TMS folder ID (or interactive picker in TTY)
 ```
 
+> **Project / folder management — Read `references/test-manager.md`** for the full agent surface: `kane-cli projects list|create` and `kane-cli folders list|create` (with `--search` / `--limit` / `--offset` / `--description`), the NDJSON wire shape for `--agent` callers, and the `project_folder_auto_defaulted` event the run-startup gate emits when nothing is configured.
+
 ### Feedback
 
 Submit feedback on a completed test run:

--- a/skill-installer/skills/references/test-manager.md
+++ b/skill-installer/skills/references/test-manager.md
@@ -1,0 +1,141 @@
+<!-- Read this for the Test Manager (TMS) agent surface — what gets uploaded, where the run lands, the `projects` / `folders` subcommands and their NDJSON wire shape, and the run-startup auto-default event. Non-TTY surface only; the human config flow / interactive picker lives in the public user guide. -->
+
+# Test Manager Reference — Agent Surface
+
+Every kane-cli session uploads to a TestmuAI **Test Manager (TMS)** test case. The session lands inside a **project** (required) and optionally a **folder** inside that project. This page is the agent-facing surface for everything that touches TMS: where the run ends up, how to browse and create projects/folders programmatically, and the event the run-startup gate emits when nothing is configured.
+
+Field names below are for parsing only — translate to plain language for the user, per the §5 rule in `SKILL.md`.
+
+---
+
+## 1. Where a run lands
+
+After a successful upload, the terminal `run_end` event (`testmd_done` for `testmd run`) carries the dashboard link:
+
+```json
+{"type":"run_end","status":"passed", "test_url":"https://test-manager.lambdatest.com/projects/<id>/test-cases/<id>", ...}
+```
+
+For `testmd run`, the `test_md_summary` / `test_md_done` events also carry a `share_url` — a 7-day, no-login link suitable for CI artifacts.
+
+Surface `test_url` (and `share_url` when present) as a "View in Test Manager" line per the §1.4 results table in `SKILL.md`. Never paste raw URLs into the middle of a summary — they belong in the results table.
+
+---
+
+## 2. Projects & folders — selecting where uploads land
+
+Two ways an agent influences placement:
+
+- **Programmatically**, via the `projects` / `folders` subcommands (§3 + §4) — list, search, create, then persist with `kane-cli config project <id>` / `kane-cli config folder <id>`.
+- **Passively**, by observing the `project_folder_auto_defaulted` event the run-startup gate emits when nothing is configured (§5).
+
+In a non-TTY context (CI, pipes, every `--agent` caller), the no-arg form of `config project` / `config folder` will not prompt — always pass an explicit `<id>`. The interactive picker is the human-facing path and is documented in the user guide.
+
+---
+
+## 3. Listing — `projects list` / `folders list`
+
+```bash
+kane-cli projects list [--search <q>] [--limit <n>] [--offset <n>] --agent
+kane-cli folders  list [--search <q>] [--limit <n>] [--offset <n>] --agent
+```
+
+| Flag | Purpose |
+|---|---|
+| `--search <q>` | Filter by name (substring match). |
+| `--limit <n>` | Page size. Default is small (~10). Very large values are capped. |
+| `--offset <n>` | Skip the first N rows. |
+| `--agent` | Force NDJSON. Auto-on when stdout is piped/redirected, but pass it explicitly anyway. |
+
+`folders list` operates inside the currently configured project. If none is configured, list projects first or rely on §5.
+
+### Wire shape
+
+Each result line:
+
+```json
+{"id":"01J69X773TSY9TCHZY4VAT9VBH","name":"KaneAI Generated"}
+```
+
+Just `id` + `name`. The terminal line on every page:
+
+```json
+{"_meta":"page","limit":10,"offset":0,"returned":10,"has_more":true}
+```
+
+| Field | Meaning |
+|---|---|
+| `_meta: "page"` | Discriminator — distinguishes pagination metadata from a result row. Skip when collecting results. |
+| `limit` / `offset` | Echoed from the request. |
+| `returned` | Number of result rows on this page (≤ `limit`). |
+| `has_more` | `true` if another page exists. There is no `total` — only a "more remaining" signal, so don't promise an exact count to the user. |
+
+### Pagination idiom
+
+```bash
+offset=0; limit=10
+while :; do
+  page=$(kane-cli projects list --limit "$limit" --offset "$offset" --agent)
+  echo "$page" | jq -c 'select(._meta != "page")'    # result rows
+  more=$(echo "$page" | jq -r 'select(._meta == "page") | .has_more')
+  [ "$more" = "true" ] || break
+  offset=$((offset + limit))
+done
+```
+
+Same pattern for `folders list`.
+
+---
+
+## 4. Creating — `projects create` / `folders create`
+
+```bash
+kane-cli projects create "<name>" [--description "<text>"] --agent
+kane-cli folders  create "<name>" [--description "<text>"] --agent
+```
+
+NDJSON: one line describing the new id + name. `folders create` files the folder inside the currently configured project.
+
+To use the result for subsequent runs, persist with `kane-cli config project <id>` / `kane-cli config folder <id>` — non-interactive when called with an explicit `<id>`.
+
+---
+
+## 5. The run-startup auto-default event
+
+`kane-cli run`, `kane-cli testmd run`, and `kane-cli generate` all validate the cached project/folder before launching anything. Three outcomes:
+
+1. **Cached project/folder still valid** → run proceeds. No event.
+2. **Nothing configured, or the cached IDs are gone / inaccessible** → kane-cli resolves a sensible project/folder headlessly (find-or-create), then emits a typed event before the run starts:
+
+   ```
+   {"type": "project_folder_auto_defaulted", ...}
+   ```
+
+   The event carries the resolved project + folder so the caller knows what was picked. Translate it for the human user — for example:
+
+   > kane-cli auto-selected project **<name>** / folder **<name>** for this run.
+
+   Don't surface raw field names.
+
+3. **No usable credentials in a non-TTY context** → exit code `2` with an auth/setup error.
+
+### Self-healing for stale IDs
+
+If a previously-configured project/folder becomes unusable (deleted, renamed, access revoked, or a typo was saved as the ID), TMS returns a `4xx` for the validation call and the gate treats both as **missing** — it clears the stale value and re-resolves via auto-default. The run is not aborted for this.
+
+Transient validation failures (`5xx`, network, timeout) are treated as **error** and the gate fails open with the cached IDs so brief upstream hiccups don't block a run.
+
+### When you see the event
+
+Surface it as a one-line note, then continue parsing the run normally. If the user wants their runs in a different project, point them at the user guide's project/folder configuration page — the public `kane-cli config project [<id>]` / `kane-cli config folder [<id>]` commands cover the human flow.
+
+---
+
+## 6. Exit codes (TMS subcommands only)
+
+| Code | Meaning |
+|---|---|
+| 0 | OK |
+| 2 | Auth/setup error (missing or invalid credentials) or unknown subcommand |
+
+Other codes are run-specific (`run` / `testmd run` / `generate`) and don't apply to `projects` / `folders`.

--- a/skill-installer/skills/references/testmd.md
+++ b/skill-installer/skills/references/testmd.md
@@ -44,6 +44,8 @@ Run it:
 kane-cli testmd run amazon_test.md --agent
 ```
 
+> Before the test launches, kane-cli validates the cached project/folder. If none is configured (or the cached one is stale/invalid), the run-startup gate auto-defaults a project/folder and emits a `project_folder_auto_defaulted` event on stdout. Surface it as a one-line note for the user and keep parsing — full handling lives in `references/test-manager.md`.
+
 ## File format
 
 Four parts in order:


### PR DESCRIPTION
## Summary

Aligns the public docs, the kane-cli skill, and the Kiro power with the 0.4.1 behavior shipping in the next release: a run-startup gate that auto-defaults a project/folder, new `projects`/`folders` subcommands, and a fully self-healing path when cached IDs go stale. Also closes a pre-existing gap in the Kiro power, which had no coverage of `kane-cli generate` at all.

### What changed, by surface

**Skill (`skill-installer/skills/`)**
- New `references/test-manager.md` — agent-facing reference for the TMS surface: `projects`/`folders list|create` with NDJSON wire shape + pagination, the `project_folder_auto_defaulted` event, and self-healing semantics.
- `SKILL.md` §1.3 / §3 / §5 thread the new event + the bare-objective guardrail.
- `references/parsing.md` and `references/generate-parsing.md` list `project_folder_auto_defaulted` in their typed-event tables.
- `references/testmd.md` and `references/generate.md` note that the gate fires before launch.
- `references/debug.md` updates the exit-2 row, adds a 'did you mean' row, and adds a self-healing row.
- `references/setup-and-config.md` hints at the new reference.

**User guide (`docs/user-guide/`)**
- `configuration.md`, `test-manager-integration.md` — picker now works for both OAuth and basic-auth, new project/folder list/create commands, auto-default-on-first-run section, self-healing note.
- `cicd.md` — explicitly says project/folder is optional in CI.
- `troubleshooting.md` — 'empty project_id' is no longer fatal; stale/invalid IDs are self-healed.
- `running-tests.md` — exit-code table names TMS credential exchange + unknown subcommand under exit 2.
- README.md + 3 user-guide files — fixed stale `tms-integration.md` references to point at `test-manager-integration.md`.

**Kiro mirror (`integrations/kiro-powers/`)**
- New `steering/kane-cli-generate.md` — full parallel to `kane-cli-run.md` and `kane-cli-testmd.md`, mirroring SKILL.md §6 + `references/generate.md` + `references/generate-parsing.md`. Closes the long-standing gap where Kiro had no generate coverage.
- `POWER.md` — `displayName` / `description` / `keywords` activate on test-authoring phrasing; Overview goes from 'two ways' to 'three ways'; Steering files section adds `kane-cli-generate.md`; Step 3 reframes project/folder as optional.
- `kane-cli-run.md` — decision tree adds the 'test cases written / no browser' branch, mirrored event table + failure rows, new project/folder management sections.
- `kane-cli-testmd.md` — gate-fires-before-launch note + new 'Authoring `_test.md` from a description — generate → testmd pipeline' section.
- `integrations/docs/kiro-powers.md` — mapping guide updated to include SKILL.md §6, `references/generate.md`, `references/generate-parsing.md`, and `references/test-manager.md`.

## Commits

- `691feed` docs: ground project/folder + auto-default behavior across skill and user guide
- `a8b094a` docs: thread project/folder gate + auto-default event through skill, refs, and kiro mirror
- `3cf460d` kiro-powers: mirror generate skill + test-manager reference

## Test plan

- [ ] Render the new `test-manager.md` and `kane-cli-generate.md` references locally to confirm they read cleanly.
- [ ] Spot-check the four user-guide files (`configuration.md`, `test-manager-integration.md`, `cicd.md`, `troubleshooting.md`) for consistency.
- [ ] Confirm the mapping table in `integrations/docs/kiro-powers.md` matches the actual files under `integrations/kiro-powers/`.
- [ ] Sanity-check that no internal/private-repo references leaked into any of the docs (grep for `LambdatestIncPrivate` / `v16-controller` etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)