### PR TITLE
docs: browser state actions — cookies, localStorage, clipboard

### DIFF
--- a/.agents/skills/kane-cli/SKILL.md
+++ b/.agents/skills/kane-cli/SKILL.md
@@ -197,7 +197,7 @@ kane-cli run "Go to https://app.example.com and login with {{username}} and {{pa
 
 How you phrase the objective string determines what the agent does. Three patterns:
 
-> For the full catalog — every action verb, every assertion analyze method (Visual / Textual-DOM / URL / Title / DevTools→Network/Console/Performance/Cookies/localStorage), operators, chaining, conditional/negative patterns, and worked examples — Read `references/objectives-cookbook.md`. Same grammar applies to one-shot `kane-cli run` objectives and `_test.md` step bodies.
+> For the full catalog — every action verb, every assertion analyze method (Visual / Textual-DOM / URL / Title / DevTools→Network/Console/Performance/Cookies/localStorage/Clipboard), operators, chaining, conditional/negative patterns, and worked examples — Read `references/objectives-cookbook.md`. Same grammar applies to one-shot `kane-cli run` objectives and `_test.md` step bodies.
 
 | Pattern | Trigger words | Behavior |
 |---|---|---|

--- a/.agents/skills/kane-cli/references/objectives-cookbook.md
+++ b/.agents/skills/kane-cli/references/objectives-cookbook.md
@@ -37,9 +37,17 @@ Reference list. Use these in your prose; the agent recognizes them all.
 | **Scroll/drag** | scroll to, scroll down/up, drag to, drop on |
 | **Wait** | wait for, wait until, pause for |
 | **File** | upload, attach, download |
+| **Cookies** | set cookie name=value, delete the X cookie, clear all cookies |
+| **localStorage** | set localStorage key=value, delete the X key from localStorage, clear localStorage |
+| **Clipboard** | write X to the clipboard, paste from the clipboard, clear the clipboard |
 | **Misc** | dismiss, accept dialog, switch frame, take screenshot |
 
 Always include a **starting URL** somewhere in the first action verb if the agent needs to navigate. Never assume the agent knows where to start.
+
+Browser-state notes:
+- **Cookies**: values accept `{{variables}}`. A cookie without a domain applies to the current page's site — navigate first. Reload after setting if the page must pick it up.
+- **localStorage**: per-site — navigate to the target site before setting. Reload if the app only reads storage on load.
+- **Clipboard**: the run uses an **isolated test clipboard** — your real OS clipboard is never read or written. Site Copy buttons are captured into it automatically. To paste: click/focus the target field first, then say paste (Ctrl/Cmd+V works too). Text and images both paste.
 
 ---
 
@@ -168,6 +176,19 @@ Get all localStorage keys
 
 If localStorage has "onboarding_complete" then show dashboard, else start onboarding
 ```
+
+#### Clipboard
+
+The test's isolated clipboard (the OS clipboard is never involved). Holds **one current entry** — every copy or clipboard write replaces it, so **verify a clipboard value before the next clipboard write/clear**. An entry can carry text, HTML, and an image at once (e.g. a site's "Copy image" button).
+
+```text
+Click the Copy link button, then verify the clipboard contains "/inv/42"
+Store the copied coupon code as 'coupon'
+Verify an image was copied to the clipboard
+Write "INV-2026-042" to the clipboard, verify the clipboard contains "INV-2026-042", then clear the clipboard and verify the clipboard text is empty
+```
+
+Do **not** paste into a field just to check a copied value — assert on the clipboard directly. For absence checks, prefer positive phrasing ("verify the clipboard text is empty") over negations.
 
 ### 3.3 Operators
 
@@ -313,6 +334,9 @@ Positional assertions check where something is on the page:
 ---
 
 ## 8. Common pitfalls
+
+- **Setting localStorage or clipboard before navigating** — both need a page loaded first (storage is per-site; the clipboard tools live in the page). Navigate, then mutate.
+- **Clipboard checkpoint after the next clipboard mutation** — the clipboard holds one entry; a later write/clear replaces it. Verify immediately after the copy/write you're checking.
 
 | ❌ Don't | ✅ Do | Why |
 |---|---|---|

--- a/.claude/skills/kane-cli/SKILL.md
+++ b/.claude/skills/kane-cli/SKILL.md
@@ -197,7 +197,7 @@ kane-cli run "Go to https://app.example.com and login with {{username}} and {{pa
 
 How you phrase the objective string determines what the agent does. Three patterns:
 
-> For the full catalog — every action verb, every assertion analyze method (Visual / Textual-DOM / URL / Title / DevTools→Network/Console/Performance/Cookies/localStorage), operators, chaining, conditional/negative patterns, and worked examples — Read `references/objectives-cookbook.md`. Same grammar applies to one-shot `kane-cli run` objectives and `_test.md` step bodies.
+> For the full catalog — every action verb, every assertion analyze method (Visual / Textual-DOM / URL / Title / DevTools→Network/Console/Performance/Cookies/localStorage/Clipboard), operators, chaining, conditional/negative patterns, and worked examples — Read `references/objectives-cookbook.md`. Same grammar applies to one-shot `kane-cli run` objectives and `_test.md` step bodies.
 
 | Pattern | Trigger words | Behavior |
 |---|---|---|

--- a/.claude/skills/kane-cli/references/objectives-cookbook.md
+++ b/.claude/skills/kane-cli/references/objectives-cookbook.md
@@ -37,9 +37,17 @@ Reference list. Use these in your prose; the agent recognizes them all.
 | **Scroll/drag** | scroll to, scroll down/up, drag to, drop on |
 | **Wait** | wait for, wait until, pause for |
 | **File** | upload, attach, download |
+| **Cookies** | set cookie name=value, delete the X cookie, clear all cookies |
+| **localStorage** | set localStorage key=value, delete the X key from localStorage, clear localStorage |
+| **Clipboard** | write X to the clipboard, paste from the clipboard, clear the clipboard |
 | **Misc** | dismiss, accept dialog, switch frame, take screenshot |
 
 Always include a **starting URL** somewhere in the first action verb if the agent needs to navigate. Never assume the agent knows where to start.
+
+Browser-state notes:
+- **Cookies**: values accept `{{variables}}`. A cookie without a domain applies to the current page's site — navigate first. Reload after setting if the page must pick it up.
+- **localStorage**: per-site — navigate to the target site before setting. Reload if the app only reads storage on load.
+- **Clipboard**: the run uses an **isolated test clipboard** — your real OS clipboard is never read or written. Site Copy buttons are captured into it automatically. To paste: click/focus the target field first, then say paste (Ctrl/Cmd+V works too). Text and images both paste.
 
 ---
 
@@ -168,6 +176,19 @@ Get all localStorage keys
 
 If localStorage has "onboarding_complete" then show dashboard, else start onboarding
 ```
+
+#### Clipboard
+
+The test's isolated clipboard (the OS clipboard is never involved). Holds **one current entry** — every copy or clipboard write replaces it, so **verify a clipboard value before the next clipboard write/clear**. An entry can carry text, HTML, and an image at once (e.g. a site's "Copy image" button).
+
+```text
+Click the Copy link button, then verify the clipboard contains "/inv/42"
+Store the copied coupon code as 'coupon'
+Verify an image was copied to the clipboard
+Write "INV-2026-042" to the clipboard, verify the clipboard contains "INV-2026-042", then clear the clipboard and verify the clipboard text is empty
+```
+
+Do **not** paste into a field just to check a copied value — assert on the clipboard directly. For absence checks, prefer positive phrasing ("verify the clipboard text is empty") over negations.
 
 ### 3.3 Operators
 
@@ -313,6 +334,9 @@ Positional assertions check where something is on the page:
 ---
 
 ## 8. Common pitfalls
+
+- **Setting localStorage or clipboard before navigating** — both need a page loaded first (storage is per-site; the clipboard tools live in the page). Navigate, then mutate.
+- **Clipboard checkpoint after the next clipboard mutation** — the clipboard holds one entry; a later write/clear replaces it. Verify immediately after the copy/write you're checking.
 
 | ❌ Don't | ✅ Do | Why |
 |---|---|---|

--- a/docs/user-guide/features/browser-state.md
+++ b/docs/user-guide/features/browser-state.md
@@ -1,0 +1,53 @@
+# Browser State Actions
+
+Objectives can directly manage cookies, localStorage, and the clipboard — useful for seeding state before a flow (skip a login, dismiss a consent banner) and for testing copy/paste behavior.
+
+## Cookies
+
+```
+Set a cookie named session with value abc123
+Set cookies consent=yes and tracking=off, then reload the page
+Delete the consent cookie
+Clear all cookies
+```
+
+- Values accept `{{variables}}`: `set a cookie named session with value {{auth_token}}`
+- A cookie without an explicit domain applies to the **current page's site** — navigate first
+- Reload or navigate after setting if the page must pick the cookie up
+- Provide `path` together with a domain; a path alone is rejected by the browser
+
+## localStorage
+
+```
+Set localStorage keys theme=dark and lang=en
+Delete the lang key from localStorage
+Clear localStorage
+```
+
+- Storage is **per-site** — navigate to the target site before setting
+- Reload after setting if the app only reads storage on page load
+- Values accept `{{variables}}`
+
+## Clipboard
+
+The run uses an **isolated test clipboard** — your real OS clipboard is never read or written. Site Copy buttons are captured into it automatically.
+
+```
+Write "John Tester" to the clipboard
+Click the message field, then paste from the clipboard
+Clear the clipboard
+```
+
+- **Paste targets the focused field** — click or focus the field first, then paste (`Ctrl/Cmd+V` in an objective works the same way)
+- Text and images both paste; rich editors receive a real paste event
+- Typical flows: *write → click field → paste*, or *click the site's Copy button → click field → paste*
+
+## Verifying state
+
+Each of these has a matching assertion family — see [Cookies](./checkpoints/devtools/cookies.md), [localStorage](./checkpoints/devtools/local-storage.md), and [Clipboard](./checkpoints/devtools/clipboard.md):
+
+```
+Set a cookie named session with value abc123, reload, and verify the page shows you as logged in
+Set localStorage theme=dark, reload, and verify the dark theme is active
+Click the Copy link button, then verify the clipboard contains "/invoice/42"
+```

--- a/docs/user-guide/features/checkpoints/devtools/clipboard.md
+++ b/docs/user-guide/features/checkpoints/devtools/clipboard.md
@@ -1,0 +1,61 @@
+# Clipboard Assertions
+
+Clipboard assertions let you verify what a "Copy" button actually copied, extract copied values into variables, and confirm clipboard state after your test writes or clears it.
+
+## The Test Clipboard
+
+Every run uses an **isolated test clipboard**:
+
+- **Your real clipboard is safe**: the OS clipboard is never read and never written — tests can't leak your copied data into results, and nothing you copy mid-run interferes with the test
+- **Automatic capture**: when the page copies something (a Copy button, Ctrl/Cmd+C on a selection), it lands in the test clipboard
+- **One current entry**: like a real clipboard, every copy or clipboard write **replaces** the previous content
+- **Multi-format**: a single entry can carry plain text, HTML, and an image together (e.g. a "Copy image" button)
+- **Same behavior everywhere**: headless, headed, and CI runs all behave identically
+
+### Planning for Multi-Step Tests
+
+Because the clipboard holds one entry at a time:
+
+- Verify a copied value **immediately after** the copy or write that produced it — a later clipboard write/clear replaces it
+- To check several copies, interleave: copy A → verify → copy B → verify
+
+## What You Can Query
+
+| Query | Description |
+|-------|-------------|
+| text content | The plain-text content of the clipboard ("" when empty) |
+| HTML content | The rich-text representation, when present |
+| formats present | Which content types the entry carries (text, HTML, image) |
+| image presence/size | Whether an image was copied, and its byte size |
+
+## Example Assertions
+
+```
+Click the "Copy link" button, then verify the clipboard contains "/invoice/42"
+Verify the clipboard text is "INV-2026-042"
+Verify an image was copied to the clipboard
+Verify the clipboard text is empty
+```
+
+## Example Extractions
+
+```
+Click the Copy button, store the copied coupon code as 'coupon'
+Store the clipboard text as 'copied_link'
+```
+
+Stored values work like any other variable — fill `{{coupon}}` into a field later, or assert on it.
+
+## Writing and Pasting (actions)
+
+The clipboard isn't read-only — objectives can also drive it. See [Browser State Actions](../../browser-state.md):
+
+```
+Write "John Tester" to the clipboard, click the message field, then paste from the clipboard
+```
+
+## Tips
+
+- **Don't paste to verify** — assert on the clipboard directly instead of pasting into a field and reading it back
+- **Prefer positive phrasing** for empties: "verify the clipboard text is empty" rather than "verify X is not on the clipboard"
+- Clipboard actions need a page loaded first — navigate before writing or pasting

--- a/docs/user-guide/features/checkpoints/devtools/overview.md
+++ b/docs/user-guide/features/checkpoints/devtools/overview.md
@@ -11,6 +11,7 @@ DevTools assertions let you verify data that isn't visible on the page — HTTP 
 | [Performance](./performance.md) | Core Web Vitals | LCP, CLS, INP, FCP, TTFB |
 | [Cookies](./cookies.md) | Browser cookies | Names, values, flags (httpOnly, secure, sameSite) |
 | [localStorage](./local-storage.md) | Browser localStorage | Key-value pairs stored in the browser |
+| [Clipboard](./clipboard.md) | Test clipboard | Copied text/HTML/images — verify Copy buttons, extract copied values |
 
 ## How It Works
 

--- a/docs/user-guide/features/checkpoints/overview.md
+++ b/docs/user-guide/features/checkpoints/overview.md
@@ -22,7 +22,7 @@ Each checkpoint uses an analyze method to determine *where* to look for the data
 | [Textual (DOM)](./textual.md) | Page DOM elements | Element states (disabled, checked), CSS properties, HTML attributes |
 | [URL](./url.md) | Browser URL bar | URL path, query params, redirects |
 | [Title](./title.md) | Page title | Document title verification |
-| [DevTools](./devtools/) | Browser internals | Network traffic, console logs, performance, cookies, localStorage |
+| [DevTools](./devtools/) | Browser internals | Network traffic, console logs, performance, cookies, localStorage, clipboard |
 
 ## How to Use
 
@@ -38,6 +38,7 @@ Assert: no console errors                      → DevTools (Console)
 Assert: page LCP is under 2500ms               → DevTools (Performance)
 Assert: session cookie exists                  → DevTools (Cookies)
 Assert: auth_token exists in localStorage      → DevTools (localStorage)
+Assert: clipboard contains the copied link     → DevTools (Clipboard)
 ```
 
 Extractions work the same way:
@@ -68,4 +69,4 @@ Assertions support these comparison operators:
 - [Textual (DOM) Assertions](./textual.md) — element states and attributes
 - [URL Assertions](./url.md) — URL-based checks
 - [Title Assertions](./title.md) — page title checks
-- [DevTools Assertions](./devtools/) — network, console, performance, cookies, localStorage
+- [DevTools Assertions](./devtools/) — network, console, performance, cookies, localStorage, clipboard

--- a/docs/user-guide/running-tests.md
+++ b/docs/user-guide/running-tests.md
@@ -30,6 +30,15 @@ Open https://app.example.com, log in with the credentials in {{tester}},
 navigate to Settings > Billing, and verify the current plan is "Pro".
 ```
 
+```text
+Open https://app.example.com, set a cookie named session with value
+{{auth_token}}, reload, and verify the dashboard loads. Then click the
+"Copy invite link" button and verify the clipboard contains "/invite/".
+```
+
+Objectives can also set, delete, and clear cookies, localStorage, and the
+test clipboard directly — see [Browser State Actions](./features/browser-state.md).
+
 ### Bad to better
 
 | | Objective |

--- a/docs/user-guide/variables-and-context.md
+++ b/docs/user-guide/variables-and-context.md
@@ -8,6 +8,8 @@ This page covers how `kane-cli` discovers and merges variables, how to mark valu
 
 ### Variable format
 
+`{{variables}}` resolve anywhere a value is typed or set — form fills, cookie and localStorage values, and clipboard writes alike.
+
 Variables are JSON objects keyed by name. Each entry describes a single variable.
 
 ```json

--- a/integrations/kiro-powers/POWER.md
+++ b/integrations/kiro-powers/POWER.md
@@ -147,6 +147,7 @@ Three ways Kiro uses it:
 
 Other capabilities to know about:
 
+- **Browser state control** — objectives can set/delete/clear cookies and localStorage, and write/paste/clear an isolated test clipboard (the OS clipboard is never touched); matching assertions verify each ("verify the clipboard contains X", "verify the session cookie exists").
 - **Variables and secrets** via `--variables` / `--variables-file` and `{{name}}` placeholders in objectives. `secret: true` masks the value in logs.
 - **Local or remote browsers** — local Chrome by default; `--cdp-endpoint <url>` attaches to a running Chrome; `--ws-endpoint <url>` drives a remote browser (e.g. LambdaTest grid).
 - **Context files** — `~/.testmuai/kaneai/global-memory.md` is global; `.testmuai/context.md` (in cwd) is project-local; override per-run with `--global-context` / `--local-context`.

--- a/skill-installer/skills/SKILL.md
+++ b/skill-installer/skills/SKILL.md
@@ -197,7 +197,7 @@ kane-cli run "Go to https://app.example.com and login with {{username}} and {{pa
 
 How you phrase the objective string determines what the agent does. Three patterns:
 
-> For the full catalog — every action verb, every assertion analyze method (Visual / Textual-DOM / URL / Title / DevTools→Network/Console/Performance/Cookies/localStorage), operators, chaining, conditional/negative patterns, and worked examples — Read `references/objectives-cookbook.md`. Same grammar applies to one-shot `kane-cli run` objectives and `_test.md` step bodies.
+> For the full catalog — every action verb, every assertion analyze method (Visual / Textual-DOM / URL / Title / DevTools→Network/Console/Performance/Cookies/localStorage/Clipboard), operators, chaining, conditional/negative patterns, and worked examples — Read `references/objectives-cookbook.md`. Same grammar applies to one-shot `kane-cli run` objectives and `_test.md` step bodies.
 
 | Pattern | Trigger words | Behavior |
 |---|---|---|

--- a/skill-installer/skills/references/objectives-cookbook.md
+++ b/skill-installer/skills/references/objectives-cookbook.md
@@ -37,9 +37,17 @@ Reference list. Use these in your prose; the agent recognizes them all.
 | **Scroll/drag** | scroll to, scroll down/up, drag to, drop on |
 | **Wait** | wait for, wait until, pause for |
 | **File** | upload, attach, download |
+| **Cookies** | set cookie name=value, delete the X cookie, clear all cookies |
+| **localStorage** | set localStorage key=value, delete the X key from localStorage, clear localStorage |
+| **Clipboard** | write X to the clipboard, paste from the clipboard, clear the clipboard |
 | **Misc** | dismiss, accept dialog, switch frame, take screenshot |
 
 Always include a **starting URL** somewhere in the first action verb if the agent needs to navigate. Never assume the agent knows where to start.
+
+Browser-state notes:
+- **Cookies**: values accept `{{variables}}`. A cookie without a domain applies to the current page's site — navigate first. Reload after setting if the page must pick it up.
+- **localStorage**: per-site — navigate to the target site before setting. Reload if the app only reads storage on load.
+- **Clipboard**: the run uses an **isolated test clipboard** — your real OS clipboard is never read or written. Site Copy buttons are captured into it automatically. To paste: click/focus the target field first, then say paste (Ctrl/Cmd+V works too). Text and images both paste.
 
 ---
 
@@ -168,6 +176,19 @@ Get all localStorage keys
 
 If localStorage has "onboarding_complete" then show dashboard, else start onboarding
 ```
+
+#### Clipboard
+
+The test's isolated clipboard (the OS clipboard is never involved). Holds **one current entry** — every copy or clipboard write replaces it, so **verify a clipboard value before the next clipboard write/clear**. An entry can carry text, HTML, and an image at once (e.g. a site's "Copy image" button).
+
+```text
+Click the Copy link button, then verify the clipboard contains "/inv/42"
+Store the copied coupon code as 'coupon'
+Verify an image was copied to the clipboard
+Write "INV-2026-042" to the clipboard, verify the clipboard contains "INV-2026-042", then clear the clipboard and verify the clipboard text is empty
+```
+
+Do **not** paste into a field just to check a copied value — assert on the clipboard directly. For absence checks, prefer positive phrasing ("verify the clipboard text is empty") over negations.
 
 ### 3.3 Operators
 
@@ -313,6 +334,9 @@ Positional assertions check where something is on the page:
 ---
 
 ## 8. Common pitfalls
+
+- **Setting localStorage or clipboard before navigating** — both need a page loaded first (storage is per-site; the clipboard tools live in the page). Navigate, then mutate.
+- **Clipboard checkpoint after the next clipboard mutation** — the clipboard holds one entry; a later write/clear replaces it. Verify immediately after the copy/write you're checking.
 
 | ❌ Don't | ✅ Do | Why |
 |---|---|---|


### PR DESCRIPTION
Objectives can now set/delete/clear cookies and localStorage, and write/paste/clear an isolated test clipboard (OS clipboard never touched; site Copy buttons captured automatically), with matching clipboard assertions/extractions.

- skills (all 3 copies): action-verb catalog rows, Clipboard analyze section, browser-state notes, two new pitfalls
- user-guide: new features/browser-state.md and checkpoints/devtools/clipboard.md; overview tables, running-tests example, variables note
- integrations: capability line in kiro POWER.md