### PR TITLE
feat: Discord community link + auto-announce releases

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -1,0 +1,99 @@
+name: Announce release on Discord
+
+# Posts every published GitHub Release to the kane-cli Discord announcement
+# channel and crossposts (publishes) it to servers that follow that channel.
+# Requires the DISCORD_BOT_TOKEN secret (a bot with View Channels + Send
+# Messages + Embed Links in the announcement channel).
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    runs-on: ubuntu-latest
+    # Skip drafts/pre-releases on the release trigger; always run for manual dispatch.
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+    steps:
+      - name: Post release announcement to Discord
+        uses: actions/github-script@v7
+        env:
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
+        with:
+          script: |
+            const CHANNEL_ID = '1513614044165312522';
+            const API = 'https://discord.com/api/v10';
+            const token = process.env.DISCORD_BOT_TOKEN;
+
+            if (!token) {
+              core.warning('DISCORD_BOT_TOKEN is not set; skipping announcement.');
+              return;
+            }
+
+            // Use the release from the event, or fall back to the latest published
+            // release so a manual workflow_dispatch run can be used to re-send/test.
+            let release = context.payload.release;
+            if (!release) {
+              const { data } = await github.rest.repos.getLatestRelease({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+              });
+              release = data;
+            }
+
+            const url = release.html_url;
+            const title = (release.name || release.tag_name || 'New release').slice(0, 256);
+            const body = (release.body || '').trim();
+
+            // Discord embed descriptions are capped at 4096 chars; leave room for the link.
+            const LIMIT = 4000;
+            let description;
+            if (!body) {
+              description = `A new version of kane-cli is out.\n\n[Release notes →](${url})`;
+            } else if (body.length > LIMIT) {
+              description = body.slice(0, LIMIT).trimEnd() + `\n\n…\n\n[Full release notes →](${url})`;
+            } else {
+              description = body;
+            }
+
+            const embed = {
+              title,
+              url,
+              description,
+              color: 0x5865F2,
+              timestamp: release.published_at || undefined,
+              footer: { text: 'kane-cli' },
+            };
+
+            const headers = {
+              Authorization: `Bot ${token}`,
+              'Content-Type': 'application/json',
+            };
+
+            // 1) Post the announcement to the channel.
+            const postRes = await fetch(`${API}/channels/${CHANNEL_ID}/messages`, {
+              method: 'POST',
+              headers,
+              body: JSON.stringify({ embeds: [embed] }),
+            });
+            if (!postRes.ok) {
+              throw new Error(`Discord post failed: ${postRes.status} ${await postRes.text()}`);
+            }
+            const message = await postRes.json();
+            core.info(`Posted announcement message ${message.id} for "${title}".`);
+
+            // 2) Crosspost/publish it to follower servers. Non-fatal: the message is
+            //    already visible in the channel even if crossposting fails.
+            const cpRes = await fetch(`${API}/channels/${CHANNEL_ID}/messages/${message.id}/crosspost`, {
+              method: 'POST',
+              headers,
+            });
+            if (cpRes.ok) {
+              core.info('Crossposted announcement to follower servers.');
+            } else {
+              core.warning(`Crosspost failed (message still posted): ${cpRes.status} ${await cpRes.text()}`);
+            }

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![npm version](https://img.shields.io/npm/v/@testmuai/kane-cli)](https://www.npmjs.com/package/@testmuai/kane-cli)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 ![Platforms](https://img.shields.io/badge/platforms-macOS%20%7C%20Linux%20%7C%20Windows-brightgreen)
+[![Discord](https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/kanQPEx9)
 
 ---
 
@@ -445,6 +446,7 @@ curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh
   - test.md files: [overview](docs/user-guide/testmd/overview.md) · [running](docs/user-guide/testmd/running.md) · [composition](docs/user-guide/testmd/composition.md)
   - [Test Manager integration](docs/user-guide/test-manager-integration.md) · [CI/CD recipes](docs/user-guide/cicd.md) · [Troubleshooting](docs/user-guide/troubleshooting.md)
 - **Agent setup guide** (deep reference for AI coding agents): [testmuai.com/kane-cli/agents.md](https://testmuai.com/kane-cli/agents.md)
+- **Community:** [Join us on Discord](https://discord.gg/kanQPEx9) — questions, discussion, and release announcements
 - **Issues / bug reports:** [GitHub Issues](https://github.com/LambdaTest/kane-cli/issues/new/choose)
 - **Security:** see [SECURITY.md](SECURITY.md)
 - **Contributing:** see [CONTRIBUTING.md](CONTRIBUTING.md) — improvements to documentation and skills are welcome


### PR DESCRIPTION
## What

1. **README** — adds a Discord badge to the top badge row and a **Community** bullet under *Documentation, support, contributing*, both pointing to the public invite (`discord.gg/kanQPEx9`).
2. **`.github/workflows/announce-release.yml`** (new) — automatically announces every release in the Discord announcement channel.

## How the workflow works

- Triggers on `release: { types: [published] }` (skips drafts & pre-releases) plus manual `workflow_dispatch`.
- A single `actions/github-script@v7` step builds a Discord embed from the release body, **posts** it to the announcement channel (`1513614044165312522`), then **crossposts/publishes** it to servers that follow that channel.
- Truncates at Discord's 4096-char embed limit (with a "Full release notes →" link); empty bodies get a fallback line; crosspost failure is a warning (the message still posts); a missing token no-ops with a log line.

## Requirements / notes

- Needs the **`DISCORD_BOT_TOKEN`** repo secret — a Discord bot with *View Channels + Send Messages + Embed Links* in the announcement channel.
- ⚠️ The triggers only fire from the **default branch's** copy of the workflow, so this must be merged to `main` before it activates or can be test-run.
- New release habit: cut a **GitHub Release** per version (not just push a tag) — that's the trigger. After merge, dry-run via *Actions → Announce release on Discord → Run workflow* (falls back to the latest release).
- Known limitation: crossposting only reaches servers that actually follow the announcement channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)