### PR TITLE
fix: point release announcement at the correct Discord channel

### DIFF
--- a/.github/workflows/announce-release.yml
+++ b/.github/workflows/announce-release.yml
@@ -25,7 +25,7 @@ jobs:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
         with:
           script: |
-            const CHANNEL_ID = '1513614044165312522';
+            const CHANNEL_ID = '1517976469190606848';
             const API = 'https://discord.com/api/v10';
             const token = process.env.DISCORD_BOT_TOKEN;
 


### PR DESCRIPTION
The `announce-release` workflow was targeting channel `1513614044165312522` — the channel from the original link, which turned out **not** to be the release channel — so the 0.4.6 announcement posted to the wrong place.

This points `CHANNEL_ID` at the actual **release announcement channel** (`1517976469190606848`).

No other behavior changes. After merge, re-run *Actions → Announce release on Discord → Run workflow* to post 0.4.6 to the correct channel (and delete the stray message in the wrong one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)