### PR TITLE
kiro-powers: add License and support section to POWER.md

### DIFF
--- a/integrations/docs/kiro-powers.md
+++ b/integrations/docs/kiro-powers.md
@@ -64,6 +64,7 @@ The integration is not a verbatim copy of `SKILL.md`. It adds and preserves Kiro
 6. **The "wait for `run_end`" rule** is restated prominently in `kane-cli-run.md` because the most common Kiro failure mode is the agent acting on partial output. Don't soften it.
 7. **Internal field names are internal.** `run_end`, `final_state`, `session_dir`, `run_dir`, `NDJSON` — never expose these to the user. Translate them into plain language.
 8. **Hook template ships in `hooks/`**, but the user must copy it to `.kiro/hooks/kane-verify.kiro.hook` in their own workspace. Powers don't install hooks for the user; the hook file in this repo is a template.
+9. **The `# License and support` section in POWER.md.** Kiro's power review requires a body section whose heading contains "license", naming the underlying tool's license type (Apache-2.0) and carrying at least one support / contact link. It is **harness metadata — like the frontmatter — not a CLI fact**, so it has no `SKILL.md` source by design. Don't strip it during a mirroring pass, and don't backfill it into `SKILL.md`. Its links (LICENSE, GitHub Issues, Discord, `security@testmuai.com`, docs) are absolute URLs because the power is read outside a repo checkout; keep them in sync with the root `README.md` and `SECURITY.md`.
 
 ## Things to NOT put in the integration
 
@@ -116,6 +117,7 @@ Before committing changes to the integration:
 - [ ] Steering files are named `kane-cli-run.md` / `kane-cli-testmd.md` (Kiro convention `{tool}-{workflow}.md`).
 - [ ] Steering files do **not** have `inclusion:` frontmatter (that's for workspace `.kiro/steering/` files, not in-power steering).
 - [ ] POWER.md explicitly tells Kiro when to load each steering file.
+- [ ] POWER.md has a `# License and support` section naming Apache-2.0 and at least one support link (see Kiro-specific framing #9 — required by power review, has no `SKILL.md` source).
 - [ ] The "wait for `run_end`" rule still appears prominently in `kane-cli-run.md`.
 - [ ] No internal field names (`run_end`, `final_state`, `session_dir`, `run_dir`, `NDJSON`) appear in user-facing message templates.
 - [ ] No fabricated facts: no version-specific release notes, no stdin / `/exit` protocol, no made-up UI features, no unverified download URLs.

--- a/integrations/kiro-powers/POWER.md
+++ b/integrations/kiro-powers/POWER.md
@@ -323,6 +323,20 @@ Global config lives in `~/.testmuai/kaneai/`:
 
 Do not configure Kane CLI via environment variables — env-var passthrough is not a guaranteed contract. Use `--username`, `--access-key`, `--profile`, `--variables`, `--variables-file`, and `kane-cli config …` so every run is reproducible from the command line.
 
+# License and support
+
+**License** — Kane CLI is open source under the [Apache-2.0 license](https://github.com/LambdaTest/kane-cli/blob/main/LICENSE). This power (`POWER.md`, its steering files, and the sample hook) ships under the same license. Kane CLI requires a TestMu AI account; use of the TestMu AI platform is governed by TestMu AI's own service terms, separate from the CLI's open-source license.
+
+**Support**
+
+| Need | Where to go |
+|---|---|
+| Bug reports / feature requests | [GitHub Issues](https://github.com/LambdaTest/kane-cli/issues/new/choose) |
+| Questions, discussion, releases | [Discord](https://discord.gg/kanQPEx9) |
+| Security vulnerabilities (never file publicly) | security@testmuai.com — see [SECURITY.md](https://github.com/LambdaTest/kane-cli/blob/main/SECURITY.md) |
+| User guide | [docs/user-guide](https://github.com/LambdaTest/kane-cli/tree/main/docs/user-guide) |
+| Agent reference | [testmuai.com/kane-cli/agents.md](https://testmuai.com/kane-cli/agents.md) |
+
 ---
 
 **Package:** `@testmuai/kane-cli` (npm) · **Source:** https://github.com/LambdaTest/kane-cli · **Connection:** local CLI invoked via shell — no MCP server required.


### PR DESCRIPTION
## Why

Kiro's power review flagged `integrations/kiro-powers/POWER.md` as missing a **License & support** section: the body needs a heading containing "license", naming the underlying tool's license type and carrying at least one support/contact link. POWER.md had neither — only a footer line with package/source metadata.

Worth noting: this is a *catalog review* requirement, not part of Kiro's published POWER.md spec (`kiro.dev/docs/powers/create`) — none of the shipped third-party powers (datadog, neon, postman, dynatrace) carry such a section either.

## What changed

**`integrations/kiro-powers/POWER.md`** — new `# License and support` section as the last body section, before the existing Package/Source/Connection footer:

- **License:** Apache-2.0, linked to `LICENSE`. Notes the power itself (POWER.md + steering + sample hook) ships under the same license, and that Kane CLI requires a TestMu AI account whose platform use is governed by separate service terms — the CLI's open-source license and the platform's terms are two different things.
- **Support table:** GitHub Issues, Discord, `security@testmuai.com` (+ SECURITY.md), the user guide, and the agent reference. Absolute URLs, since the power is read outside a repo checkout.

**`integrations/docs/kiro-powers.md`** — records why the section exists so a future `SKILL.md`-mirroring pass doesn't strip it as an untraceable fact:

- Kiro-specific framing item #9: the section is harness metadata (like the frontmatter), required by power review, deliberately without a `SKILL.md` source — don't delete it, don't backfill it upstream.
- A matching row in the verification checklist.

## Verification

All six links in the new section return HTTP 200. `SKILL.md` and `integrations/CLAUDE.md` are untouched — `integrations/CLAUDE.md` rule 4 ("Respect each harness's spec") already authorizes harness-required sections, and rule 3's "don't invent facts" is about CLI behavior, which this isn't. Docs-only change; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)