### PR TITLE
docs: fold objective-authoring rules into skill and user docs

### DIFF
--- a/.agents/skills/kane-cli/SKILL.md
+++ b/.agents/skills/kane-cli/SKILL.md
@@ -220,6 +220,13 @@ How you phrase the objective string determines what the agent does. Four pattern
 | 📦 **Extraction** | "store X as 'name'" | Persists a value into `run_end.final_state` |
 | 🔌 **API call** | "call", "POST/GET a URL", a pasted `curl` | The agent makes the HTTP request itself; "save the response as X", then assert/reference `{{X.status}}` / `{{X.response_body…}}` |
 
+### Two rules that make an objective replayable
+
+1. **End every flow in a terminal assertion.** Close with a check of the resulting page state (`verify the cart shows 1 item`), not a bare `submit` or `confirm the dialog`. A run only earns a replayable pass/fail from a verify/assert — a pure-action objective (`add a laptop to the cart`) gets none. If the objective has several phases, each ends in its own check. Two traps: `confirm the dialog` is an action, not a check; and `verify the Submit button is visible` fails exactly when the action worked (the control disappears on success) — assert the outcome, not the trigger.
+2. **Intent for the actions, literal for the data.** Phrase actions as goals (`Log in with {{user}}`) so the run absorbs layout drift; keep exact values literal or in `{{variables}}`. An expected-optional branch (a sometimes-there cookie banner) goes in an `if/else`, not assumed away.
+
+**Shape:** an intent action carrying literal data, then a verify of an observable end state — `Search for "{{query}}" and open the first result, then verify the title contains "{{query}}"`. Full grammar in `references/objectives-cookbook.md §1`.
+
 ### The "store as" rule (critical for extraction)
 
 Vague phrasing like "read", "tell me", "report" does NOT reliably extract data — the agent may see the value but won't capture it. Use "store as".

--- a/.agents/skills/kane-cli/references/objectives-cookbook.md
+++ b/.agents/skills/kane-cli/references/objectives-cookbook.md
@@ -25,6 +25,43 @@ Bad → better:
 
 The bad version leaves "test" undefined and gives the agent no end state. The better version names the URL, the credentials, and the assertion that closes the loop.
 
+Two rules turn those properties into a flow that replays reliably.
+
+### 1.1 End every flow in a terminal assertion
+
+Close each objective with a claim about the resulting **page state** — not a bare `submit`, not `confirm the dialog`. A closing assertion is what a replay checks: with it, the run passes or fails on the real end state; without it, "done" only means the agent believed it finished.
+
+```text
+❌ Add a laptop to the cart
+✅ Add a laptop to the cart, then verify the cart shows 1 item
+```
+
+If an objective has several phases (log in, then search, then check out), **each phase ends in its own assertion** — an intermediate phase with no check runs unverified, and a replay can't tell you which phase drifted.
+
+Two things look like assertions but are not:
+
+- **A UI-commit "confirm" is an action, not a check.** `confirm the dialog` / `click OK to confirm` presses a control; it verifies nothing about the outcome. Follow it with a real check: `… then verify the confirmation reads "Order placed"`.
+- **Don't assert the trigger.** `verify the Submit button is visible` fails exactly when the action worked — the control disappears on success. Assert the **outcome**, never the control that caused it.
+
+### 1.2 Intent for the actions, literal for the data
+
+Phrase actions as **goals**, not click-by-click scripts. A goal-level step lets the run absorb a new consent popup or a reordered form; a fixed click sequence is pinned to a layout that may have changed.
+
+```text
+❌ Click the email field, type alice@x.com, click the password field, type hunter2, click Sign in
+✅ Log in with {{user}} / {{password}}, then verify the account menu shows "{{user}}"
+```
+
+Keep exact values — credentials, search terms, prices, URLs — **literal, or lifted into `{{variables}}`** (§6). Intent for the verbs; literal or variable for the payloads.
+
+For an expected-but-optional branch (a cookie banner that only *sometimes* appears), author it as a conditional (§7) rather than assuming it away or hard-scripting it as an unconditional step.
+
+**The shape of a good step:** an intent action carrying literal data, then a verify of an observable end state —
+
+```text
+Search for "{{query}}" and open the first result, then verify the product title contains "{{query}}"
+```
+
 ---
 
 ## 2. Action verbs — quick catalog

--- a/.claude/skills/kane-cli/SKILL.md
+++ b/.claude/skills/kane-cli/SKILL.md
@@ -220,6 +220,13 @@ How you phrase the objective string determines what the agent does. Four pattern
 | 📦 **Extraction** | "store X as 'name'" | Persists a value into `run_end.final_state` |
 | 🔌 **API call** | "call", "POST/GET a URL", a pasted `curl` | The agent makes the HTTP request itself; "save the response as X", then assert/reference `{{X.status}}` / `{{X.response_body…}}` |
 
+### Two rules that make an objective replayable
+
+1. **End every flow in a terminal assertion.** Close with a check of the resulting page state (`verify the cart shows 1 item`), not a bare `submit` or `confirm the dialog`. A run only earns a replayable pass/fail from a verify/assert — a pure-action objective (`add a laptop to the cart`) gets none. If the objective has several phases, each ends in its own check. Two traps: `confirm the dialog` is an action, not a check; and `verify the Submit button is visible` fails exactly when the action worked (the control disappears on success) — assert the outcome, not the trigger.
+2. **Intent for the actions, literal for the data.** Phrase actions as goals (`Log in with {{user}}`) so the run absorbs layout drift; keep exact values literal or in `{{variables}}`. An expected-optional branch (a sometimes-there cookie banner) goes in an `if/else`, not assumed away.
+
+**Shape:** an intent action carrying literal data, then a verify of an observable end state — `Search for "{{query}}" and open the first result, then verify the title contains "{{query}}"`. Full grammar in `references/objectives-cookbook.md §1`.
+
 ### The "store as" rule (critical for extraction)
 
 Vague phrasing like "read", "tell me", "report" does NOT reliably extract data — the agent may see the value but won't capture it. Use "store as".

--- a/.claude/skills/kane-cli/references/objectives-cookbook.md
+++ b/.claude/skills/kane-cli/references/objectives-cookbook.md
@@ -25,6 +25,43 @@ Bad → better:
 
 The bad version leaves "test" undefined and gives the agent no end state. The better version names the URL, the credentials, and the assertion that closes the loop.
 
+Two rules turn those properties into a flow that replays reliably.
+
+### 1.1 End every flow in a terminal assertion
+
+Close each objective with a claim about the resulting **page state** — not a bare `submit`, not `confirm the dialog`. A closing assertion is what a replay checks: with it, the run passes or fails on the real end state; without it, "done" only means the agent believed it finished.
+
+```text
+❌ Add a laptop to the cart
+✅ Add a laptop to the cart, then verify the cart shows 1 item
+```
+
+If an objective has several phases (log in, then search, then check out), **each phase ends in its own assertion** — an intermediate phase with no check runs unverified, and a replay can't tell you which phase drifted.
+
+Two things look like assertions but are not:
+
+- **A UI-commit "confirm" is an action, not a check.** `confirm the dialog` / `click OK to confirm` presses a control; it verifies nothing about the outcome. Follow it with a real check: `… then verify the confirmation reads "Order placed"`.
+- **Don't assert the trigger.** `verify the Submit button is visible` fails exactly when the action worked — the control disappears on success. Assert the **outcome**, never the control that caused it.
+
+### 1.2 Intent for the actions, literal for the data
+
+Phrase actions as **goals**, not click-by-click scripts. A goal-level step lets the run absorb a new consent popup or a reordered form; a fixed click sequence is pinned to a layout that may have changed.
+
+```text
+❌ Click the email field, type alice@x.com, click the password field, type hunter2, click Sign in
+✅ Log in with {{user}} / {{password}}, then verify the account menu shows "{{user}}"
+```
+
+Keep exact values — credentials, search terms, prices, URLs — **literal, or lifted into `{{variables}}`** (§6). Intent for the verbs; literal or variable for the payloads.
+
+For an expected-but-optional branch (a cookie banner that only *sometimes* appears), author it as a conditional (§7) rather than assuming it away or hard-scripting it as an unconditional step.
+
+**The shape of a good step:** an intent action carrying literal data, then a verify of an observable end state —
+
+```text
+Search for "{{query}}" and open the first result, then verify the product title contains "{{query}}"
+```
+
 ---
 
 ## 2. Action verbs — quick catalog

--- a/docs/user-guide/running-tests.md
+++ b/docs/user-guide/running-tests.md
@@ -10,7 +10,13 @@ What makes a good objective:
 
 - **Specific.** Name the site, the action, and the field values where they matter.
 - **Action-oriented.** Lead with a verb: search, open, fill, click, verify.
-- **Includes a success criterion.** State what "done" looks like so the agent knows when to stop.
+- **Ends in a check of the result.** State what "done" looks like as a claim about the page, so the agent knows when to stop and a replay has something to verify.
+
+Two habits make an objective reliable enough to save and replay.
+
+**End every flow in a check of the result.** Close with an assertion about the resulting page state — `verify the cart shows 1 item` — not a bare `submit` or `confirm the dialog`. Without a closing check, "done" only means the agent believed it finished; with one, the run passes or fails on the real end state. Name the outcome, never the control that triggered it: `verify the Submit button is visible` fails exactly when the action worked, because the button disappears on success. If an objective has several phases (log in, then search, then check out), each phase ends in its own check.
+
+**Say the goal, not the clicks.** Phrase actions as goals — `Log in as {{tester}}`, `Complete checkout with the saved card` — so a run absorbs a reordered form or a new popup instead of breaking on it. Keep exact values such as credentials, prices, and URLs literal or in `{{variables}}`. For a step that only sometimes appears, such as a cookie banner, write it as a condition (`if a cookie banner appears, dismiss it`) rather than assuming it away.
 
 ### Examples
 

--- a/docs/user-guide/testmd/overview.md
+++ b/docs/user-guide/testmd/overview.md
@@ -160,7 +160,7 @@ Default is `false`, in which case any failure stops the run and marks the remain
 
 The body of a step (everything after the optional `yaml` block) must be exactly one of:
 
-- **A prose objective** — one or more lines of natural language describing what the agent should do.
+- **A prose objective** — one or more lines of natural language describing what the agent should do. A step body follows the same rules as any objective, so end it in a check of the result and phrase actions as goals — see [Writing objectives](../running-tests.md#writing-objectives).
 - **An `@import`** — a single line of the form `@import <path>` and nothing else.
 
 Mixing prose and `@import` in the same body is a parse error.

--- a/skill-installer/skills/SKILL.md
+++ b/skill-installer/skills/SKILL.md
@@ -220,6 +220,13 @@ How you phrase the objective string determines what the agent does. Four pattern
 | 📦 **Extraction** | "store X as 'name'" | Persists a value into `run_end.final_state` |
 | 🔌 **API call** | "call", "POST/GET a URL", a pasted `curl` | The agent makes the HTTP request itself; "save the response as X", then assert/reference `{{X.status}}` / `{{X.response_body…}}` |
 
+### Two rules that make an objective replayable
+
+1. **End every flow in a terminal assertion.** Close with a check of the resulting page state (`verify the cart shows 1 item`), not a bare `submit` or `confirm the dialog`. A run only earns a replayable pass/fail from a verify/assert — a pure-action objective (`add a laptop to the cart`) gets none. If the objective has several phases, each ends in its own check. Two traps: `confirm the dialog` is an action, not a check; and `verify the Submit button is visible` fails exactly when the action worked (the control disappears on success) — assert the outcome, not the trigger.
+2. **Intent for the actions, literal for the data.** Phrase actions as goals (`Log in with {{user}}`) so the run absorbs layout drift; keep exact values literal or in `{{variables}}`. An expected-optional branch (a sometimes-there cookie banner) goes in an `if/else`, not assumed away.
+
+**Shape:** an intent action carrying literal data, then a verify of an observable end state — `Search for "{{query}}" and open the first result, then verify the title contains "{{query}}"`. Full grammar in `references/objectives-cookbook.md §1`.
+
 ### The "store as" rule (critical for extraction)
 
 Vague phrasing like "read", "tell me", "report" does NOT reliably extract data — the agent may see the value but won't capture it. Use "store as".

--- a/skill-installer/skills/references/objectives-cookbook.md
+++ b/skill-installer/skills/references/objectives-cookbook.md
@@ -25,6 +25,43 @@ Bad → better:
 
 The bad version leaves "test" undefined and gives the agent no end state. The better version names the URL, the credentials, and the assertion that closes the loop.
 
+Two rules turn those properties into a flow that replays reliably.
+
+### 1.1 End every flow in a terminal assertion
+
+Close each objective with a claim about the resulting **page state** — not a bare `submit`, not `confirm the dialog`. A closing assertion is what a replay checks: with it, the run passes or fails on the real end state; without it, "done" only means the agent believed it finished.
+
+```text
+❌ Add a laptop to the cart
+✅ Add a laptop to the cart, then verify the cart shows 1 item
+```
+
+If an objective has several phases (log in, then search, then check out), **each phase ends in its own assertion** — an intermediate phase with no check runs unverified, and a replay can't tell you which phase drifted.
+
+Two things look like assertions but are not:
+
+- **A UI-commit "confirm" is an action, not a check.** `confirm the dialog` / `click OK to confirm` presses a control; it verifies nothing about the outcome. Follow it with a real check: `… then verify the confirmation reads "Order placed"`.
+- **Don't assert the trigger.** `verify the Submit button is visible` fails exactly when the action worked — the control disappears on success. Assert the **outcome**, never the control that caused it.
+
+### 1.2 Intent for the actions, literal for the data
+
+Phrase actions as **goals**, not click-by-click scripts. A goal-level step lets the run absorb a new consent popup or a reordered form; a fixed click sequence is pinned to a layout that may have changed.
+
+```text
+❌ Click the email field, type alice@x.com, click the password field, type hunter2, click Sign in
+✅ Log in with {{user}} / {{password}}, then verify the account menu shows "{{user}}"
+```
+
+Keep exact values — credentials, search terms, prices, URLs — **literal, or lifted into `{{variables}}`** (§6). Intent for the verbs; literal or variable for the payloads.
+
+For an expected-but-optional branch (a cookie banner that only *sometimes* appears), author it as a conditional (§7) rather than assuming it away or hard-scripting it as an unconditional step.
+
+**The shape of a good step:** an intent action carrying literal data, then a verify of an observable end state —
+
+```text
+Search for "{{query}}" and open the first result, then verify the product title contains "{{query}}"
+```
+
 ---
 
 ## 2. Action verbs — quick catalog


### PR DESCRIPTION
## What

Folds the two objective-authoring rules from the objective playbook into the objective guidance, **internal-free**, across the agent skill and the user docs.

1. **End every flow in a terminal assertion.** Close with a claim about the resulting page state, not a bare `submit`/`confirm`. Assert the outcome, not the disappearing trigger; a UI-commit "confirm" is an action, not a check. Each phase in a multi-phase objective ends in its own check.
2. **Intent for the actions, literal for the data.** Phrase actions as goals so a run absorbs layout drift; keep exact values literal or in `{{variables}}`; author expected-optional branches as conditionals.

## Coverage (Run + testmd, both surfaces)

| | Agent skill | User docs |
|---|---|---|
| `kane-cli run` | `SKILL.md` §4 + `objectives-cookbook.md` §1.1/§1.2 | `running-tests.md` "Writing objectives" |
| `_test.md` (testmd) | Inherits via existing `testmd.md` → `objectives-cookbook.md` reference | `testmd/overview.md` now cross-links to "Writing objectives" |

## Notes

- No internals leaked (no `cm_init` / `bifurcation` / `cp_final` / file:line in any added line).
- `objectives-cookbook.md` cross-refs are by section number, so no renumbering — the rules are added as `§1.1` / `§1.2`.
- `objectives-cookbook.md` kept byte-identical across all three skill roots (`.claude`, `.agents`, `skill-installer`).
- `_test.md` authoring inherits the rules through the existing reference; no rule duplication.

8 files changed, +140/-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)