### PR TITLE
skill: agent mode pauses on every question — pause-loop contract update

### DIFF
--- a/.agents/skills/kane-cli/references/assurance-parsing.md
+++ b/.agents/skills/kane-cli/references/assurance-parsing.md
@@ -30,7 +30,7 @@ A stream that ends **without** `done` means the process crashed — outcome unkn
 | `corpus` | extract: `sources[]` this run covers + already-extracted `skipped[]` | fold into one line |
 | `source_start` / `source_skipped` | `source_id`, `index`/`total`, `resumed` / `reason` | progress |
 | `plan` | the `--plan` transcription payload | present as the preview |
-| `assumed_default` | a question auto-answered with its recommended default: `id`, `selected_index`, `risk` | mention that defaults were assumed (they are flagged in the commit) |
+| `assumed_default` | a question auto-answered with its recommended default: `id`, `selected_index`, `risk` — 0.8.8+ agent mode never emits it (every question pauses instead); seen only on older CLIs' streams | mention that defaults were assumed (they are flagged in the commit) |
 | `agent_activity` | `kind` (`tool`/`decision`/`progress`/`thinking_done`) + display `label` | noise — fold; **never script against labels** |
 | `agent_message` *(0.7.2+)* | the agent's narrative `text` — the lead-in before a question batch, the closing statement | the story around the structured events; quote or fold, never script against it |
 | `warning` *(0.7.2+)* | actionable non-fatal condition: `code` (`ZERO_USE_CASES`, `SAVE_FAILED`) + `message` | surface it — non-fatal but user-relevant |

--- a/.agents/skills/kane-cli/references/assurance.md
+++ b/.agents/skills/kane-cli/references/assurance.md
@@ -37,7 +37,7 @@ Extract, design, and reconcile call the KaneAI service and consume credits; ever
 
 **Scope: this rule applies to `context extract`/`context ingest`, `design tests`, and `maintain reconcile` (§11).** (For `run`/`testmd`/`testrun`/`generate`, exit 3 still means timeout/cancelled.)
 
-These commands take **`--mode agent`** — not `--agent`; they reject that flag, and a bare non-TTY invocation exits `2` asking for an explicit mode. In `--mode agent`, low/medium-risk questions are auto-answered with their recommended defaults (each reported on the stream); a **high-risk** question pauses the run:
+These commands take **`--mode agent`** — not `--agent`; they reject that flag, and a bare non-TTY invocation exits `2` asking for an explicit mode. In `--mode agent`, **every question pauses the run** (0.8.8+ — earlier CLIs auto-answered low/medium-risk questions with their recommended defaults and paused only on high risk):
 
 - The run exits `3`, emits `session_paused` with the session id, the questions in full (text, options, the recommended one, risk, rationale), and the verbatim resume command.
 - **Never drop a pause** (same rule as generate clarifications). Answer it: if your own context clearly resolves the question, answer it yourself; otherwise surface the question — with its options and recommendation — to your user and get their answer.
@@ -57,7 +57,7 @@ kane-cli context extract --resume <sid> --mode agent --answer q1=1 --answer q2="
 kane-cli context extract --resume <sid> --mode agent --with-source ./addendum.md
 ```
 
-- If the answer leaves a high-risk ambiguity standing, the run pauses again with refreshed questions — repeat.
+- If the answer leaves any question standing, the run pauses again with refreshed questions — repeat.
 - Sessions live 24 hours. Inspect without contending a live run: `kane-cli context sessions --json` (all resumable sessions + their resume commands) and `kane-cli context sessions show <sid> --json` (the pending questions in wire shape). A session written by a NEWER kane-cli than the installed one lists as unknown with no resume command (0.7.1+) — that means "upgrade to resume it", not corruption. If you abandon a session deliberately, remove it with `kane-cli context sessions clean <sid>` — bare `clean` only collects *expired* sessions, and `--all` is a purge that needs explicit user authorization.
 
 Full event schema: `references/assurance-parsing.md`.

--- a/.claude/skills/kane-cli/references/assurance-parsing.md
+++ b/.claude/skills/kane-cli/references/assurance-parsing.md
@@ -30,7 +30,7 @@ A stream that ends **without** `done` means the process crashed — outcome unkn
 | `corpus` | extract: `sources[]` this run covers + already-extracted `skipped[]` | fold into one line |
 | `source_start` / `source_skipped` | `source_id`, `index`/`total`, `resumed` / `reason` | progress |
 | `plan` | the `--plan` transcription payload | present as the preview |
-| `assumed_default` | a question auto-answered with its recommended default: `id`, `selected_index`, `risk` | mention that defaults were assumed (they are flagged in the commit) |
+| `assumed_default` | a question auto-answered with its recommended default: `id`, `selected_index`, `risk` — 0.8.8+ agent mode never emits it (every question pauses instead); seen only on older CLIs' streams | mention that defaults were assumed (they are flagged in the commit) |
 | `agent_activity` | `kind` (`tool`/`decision`/`progress`/`thinking_done`) + display `label` | noise — fold; **never script against labels** |
 | `agent_message` *(0.7.2+)* | the agent's narrative `text` — the lead-in before a question batch, the closing statement | the story around the structured events; quote or fold, never script against it |
 | `warning` *(0.7.2+)* | actionable non-fatal condition: `code` (`ZERO_USE_CASES`, `SAVE_FAILED`) + `message` | surface it — non-fatal but user-relevant |

--- a/.claude/skills/kane-cli/references/assurance.md
+++ b/.claude/skills/kane-cli/references/assurance.md
@@ -37,7 +37,7 @@ Extract, design, and reconcile call the KaneAI service and consume credits; ever
 
 **Scope: this rule applies to `context extract`/`context ingest`, `design tests`, and `maintain reconcile` (§11).** (For `run`/`testmd`/`testrun`/`generate`, exit 3 still means timeout/cancelled.)
 
-These commands take **`--mode agent`** — not `--agent`; they reject that flag, and a bare non-TTY invocation exits `2` asking for an explicit mode. In `--mode agent`, low/medium-risk questions are auto-answered with their recommended defaults (each reported on the stream); a **high-risk** question pauses the run:
+These commands take **`--mode agent`** — not `--agent`; they reject that flag, and a bare non-TTY invocation exits `2` asking for an explicit mode. In `--mode agent`, **every question pauses the run** (0.8.8+ — earlier CLIs auto-answered low/medium-risk questions with their recommended defaults and paused only on high risk):
 
 - The run exits `3`, emits `session_paused` with the session id, the questions in full (text, options, the recommended one, risk, rationale), and the verbatim resume command.
 - **Never drop a pause** (same rule as generate clarifications). Answer it: if your own context clearly resolves the question, answer it yourself; otherwise surface the question — with its options and recommendation — to your user and get their answer.
@@ -57,7 +57,7 @@ kane-cli context extract --resume <sid> --mode agent --answer q1=1 --answer q2="
 kane-cli context extract --resume <sid> --mode agent --with-source ./addendum.md
 ```
 
-- If the answer leaves a high-risk ambiguity standing, the run pauses again with refreshed questions — repeat.
+- If the answer leaves any question standing, the run pauses again with refreshed questions — repeat.
 - Sessions live 24 hours. Inspect without contending a live run: `kane-cli context sessions --json` (all resumable sessions + their resume commands) and `kane-cli context sessions show <sid> --json` (the pending questions in wire shape). A session written by a NEWER kane-cli than the installed one lists as unknown with no resume command (0.7.1+) — that means "upgrade to resume it", not corruption. If you abandon a session deliberately, remove it with `kane-cli context sessions clean <sid>` — bare `clean` only collects *expired* sessions, and `--all` is a purge that needs explicit user authorization.
 
 Full event schema: `references/assurance-parsing.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- **`--mode agent` pauses on every question — it no longer answers any question itself.** `context extract`/`context ingest` and `design tests` used to auto-answer low/medium-risk questions with their recommended defaults and pause only on high risk. Now every question batch pauses the run: `session_paused` on the stream with `pending_questions[]` and the verbatim resume command, exit 3. Answer at resume (`--answer`, `--message`) or surface the question to your user. Automation that relied on the silent auto-take should use `--mode override`. `ci` mode and `maintain reconcile` are unchanged.
-
 ## [0.8.12] - 2026-09-10
 
 ### Unresolved variables are caught before the run starts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`--mode agent` pauses on every question — it no longer answers any question itself.** `context extract`/`context ingest` and `design tests` used to auto-answer low/medium-risk questions with their recommended defaults and pause only on high risk. Now every question batch pauses the run: `session_paused` on the stream with `pending_questions[]` and the verbatim resume command, exit 3. Answer at resume (`--answer`, `--message`) or surface the question to your user. Automation that relied on the silent auto-take should use `--mode override`. `ci` mode and `maintain reconcile` are unchanged.
+
 ## [0.8.7] - 2026-08-27
 
 ### Mobile testing is now fully wired in

--- a/skill-installer/skills/references/assurance-parsing.md
+++ b/skill-installer/skills/references/assurance-parsing.md
@@ -30,7 +30,7 @@ A stream that ends **without** `done` means the process crashed — outcome unkn
 | `corpus` | extract: `sources[]` this run covers + already-extracted `skipped[]` | fold into one line |
 | `source_start` / `source_skipped` | `source_id`, `index`/`total`, `resumed` / `reason` | progress |
 | `plan` | the `--plan` transcription payload | present as the preview |
-| `assumed_default` | a question auto-answered with its recommended default: `id`, `selected_index`, `risk` | mention that defaults were assumed (they are flagged in the commit) |
+| `assumed_default` | a question auto-answered with its recommended default: `id`, `selected_index`, `risk` — 0.8.8+ agent mode never emits it (every question pauses instead); seen only on older CLIs' streams | mention that defaults were assumed (they are flagged in the commit) |
 | `agent_activity` | `kind` (`tool`/`decision`/`progress`/`thinking_done`) + display `label` | noise — fold; **never script against labels** |
 | `agent_message` *(0.7.2+)* | the agent's narrative `text` — the lead-in before a question batch, the closing statement | the story around the structured events; quote or fold, never script against it |
 | `warning` *(0.7.2+)* | actionable non-fatal condition: `code` (`ZERO_USE_CASES`, `SAVE_FAILED`) + `message` | surface it — non-fatal but user-relevant |

--- a/skill-installer/skills/references/assurance.md
+++ b/skill-installer/skills/references/assurance.md
@@ -37,7 +37,7 @@ Extract, design, and reconcile call the KaneAI service and consume credits; ever
 
 **Scope: this rule applies to `context extract`/`context ingest`, `design tests`, and `maintain reconcile` (§11).** (For `run`/`testmd`/`testrun`/`generate`, exit 3 still means timeout/cancelled.)
 
-These commands take **`--mode agent`** — not `--agent`; they reject that flag, and a bare non-TTY invocation exits `2` asking for an explicit mode. In `--mode agent`, low/medium-risk questions are auto-answered with their recommended defaults (each reported on the stream); a **high-risk** question pauses the run:
+These commands take **`--mode agent`** — not `--agent`; they reject that flag, and a bare non-TTY invocation exits `2` asking for an explicit mode. In `--mode agent`, **every question pauses the run** (0.8.8+ — earlier CLIs auto-answered low/medium-risk questions with their recommended defaults and paused only on high risk):
 
 - The run exits `3`, emits `session_paused` with the session id, the questions in full (text, options, the recommended one, risk, rationale), and the verbatim resume command.
 - **Never drop a pause** (same rule as generate clarifications). Answer it: if your own context clearly resolves the question, answer it yourself; otherwise surface the question — with its options and recommendation — to your user and get their answer.
@@ -57,7 +57,7 @@ kane-cli context extract --resume <sid> --mode agent --answer q1=1 --answer q2="
 kane-cli context extract --resume <sid> --mode agent --with-source ./addendum.md
 ```
 
-- If the answer leaves a high-risk ambiguity standing, the run pauses again with refreshed questions — repeat.
+- If the answer leaves any question standing, the run pauses again with refreshed questions — repeat.
 - Sessions live 24 hours. Inspect without contending a live run: `kane-cli context sessions --json` (all resumable sessions + their resume commands) and `kane-cli context sessions show <sid> --json` (the pending questions in wire shape). A session written by a NEWER kane-cli than the installed one lists as unknown with no resume command (0.7.1+) — that means "upgrade to resume it", not corruption. If you abandon a session deliberately, remove it with `kane-cli context sessions clean <sid>` — bare `clean` only collects *expired* sessions, and `--all` is a purge that needs explicit user authorization.
 
 Full event schema: `references/assurance-parsing.md`.


### PR DESCRIPTION
Agent mode no longer auto-answers low/medium-risk questions with their recommended defaults (0.8.8+): every question batch pauses the run — `session_paused` with `pending_questions[]` and the verbatim resume command, exit 3. The driving agent answers at resume (`--answer`, `--message`) or surfaces the question to its user; `--mode override` remains the take-every-default opt-out. `ci` mode and `maintain reconcile` are unchanged.

Updated in all three skill mirrors (`skill-installer/skills`, `.agents/skills/kane-cli`, `.claude/skills/kane-cli`):

- `references/assurance.md` §2 pause loop: the auto-answer sentence becomes "every question pauses the run", and the repeat rule covers any standing question, not just high-risk.
- `references/assurance-parsing.md`: the `assumed_default` row notes it never appears on 0.8.8+ agent-mode streams.
- `CHANGELOG.md`: Unreleased "Changed" entry.

Note: the "0.8.8+" version tag assumes this ships in the next release after 0.8.7 — adjust at the release cut if the number differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
