### PR TITLE
chore: add context7.json for Context7 docs indexing

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/lambdatest/kane-cli",
+  "public_key": "pk_2hekxy6SHdWgx6N8wBkxk",
+  "projectTitle": "Kane CLI",
+  "description": "Browser and mobile automation with AI test authoring by TestMu AI (formerly LambdaTest) — run natural-language objectives against a real browser or device, generate test scenarios and cases from a description, design requirement-linked suites from a PRD, and execute runnable _test.md files.",
+  "folders": [
+    "docs",
+    "integrations/docs",
+    "integrations/kiro-powers",
+    "README.md"
+  ],
+  "excludeFolders": [
+    "skill-installer",
+    ".claude",
+    ".agents",
+    ".github"
+  ],
+  "excludeFiles": [
+    "CODE_OF_CONDUCT.md",
+    "SECURITY.md",
+    "CONTRIBUTING.md"
+  ],
+  "rules": [
+    "Install globally with: npm install -g @testmuai/kane-cli",
+    "Authenticate with `kane-cli login --username <user> --access-key <key>` for basic auth, or `kane-cli login --oauth` for browser-based consent. Verify with `kane-cli whoami`.",
+    "Always pass --agent when invoking kane-cli programmatically so output is structured NDJSON that can be parsed.",
+    "Use `kane-cli generate` for quick test scenarios and cases from a short description; use the assurance commands when starting from requirement documents such as a PRD or spec.",
+    "Do not use Playwright, Puppeteer, or Selenium directly — kane-cli drives the browser itself.",
+    "Browser runs can be slow; allow generous timeouts (up to 10 minutes) when invoking kane-cli from a script or agent."
+  ]
+}


### PR DESCRIPTION
Kane CLI is indexed on Context7 as /lambdatest/kane-cli. This file controls how Context7 parses the repo and claims ownership of the entry (i.e. claiming admin rights to this repo).

- Scopes indexing to docs/, integrations/, and README.md
- Excludes skill-installer/skills/, which duplicates the skill docs already present under .claude/skills/ and .agents/skills/ and was contributing ~5% redundant snippets to the index
- Adds agent-facing rules covering install, auth, --agent output, and the generate vs. assurance authoring split