### PR TITLE
fix: shorten context7.json description to schema limit

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -3,7 +3,7 @@
   "url": "https://context7.com/lambdatest/kane-cli",
   "public_key": "pk_2hekxy6SHdWgx6N8wBkxk",
   "projectTitle": "Kane CLI",
-  "description": "Browser and mobile automation with AI test authoring by TestMu AI (formerly LambdaTest) — run natural-language objectives against a real browser or device, generate test scenarios and cases from a description, design requirement-linked suites from a PRD, and execute runnable _test.md files.",
+  "description": "Browser and mobile automation with AI test authoring by TestMu AI — run natural-language objectives, generate test cases from a description, and design requirement-linked suites from a PRD.",
   "folders": [
     "docs",
     "integrations/docs",


### PR DESCRIPTION
Context7 ownership verification rejected the config. The description field was 291 characters; the published schema caps it at 200.

Validated against https://context7.com/schema/context7.json — the file now passes Draft-7 validation with zero errors.