### PR TITLE
docs: add Kane CLI Quickstart docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ curl -fsSL https://raw.githubusercontent.com/LambdaTest/kane-cli/main/install.sh
 
 ## Documentation, support, contributing
 
+- **Quickstart:** [Kane CLI Quickstart Guide](https://www.testmuai.com/docs/kane-cli-quickstart)
 - **User guide** (humans using the CLI/TUI):
   - [Installation](docs/user-guide/installation.md) · [Getting started](docs/user-guide/getting-started.md) · [Authentication](docs/user-guide/authentication.md)
   - [Running tests](docs/user-guide/running-tests.md) · [Configuration](docs/user-guide/configuration.md) · [Variables & context](docs/user-guide/variables-and-context.md)


### PR DESCRIPTION
## Summary
- Added specific support documentation link to README
- Replaces generic doc link with the correct product-specific documentation URL

## Context
Per TE-28506: Update npm README pages with relevant support docs links.

## Test plan
- [ ] Verify doc link renders correctly on npm after publish